### PR TITLE
Support Azure privileged creds in ZTB

### DIFF
--- a/charts/akeyless-zero-trust-bastion/Chart.yaml
+++ b/charts/akeyless-zero-trust-bastion/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.1.0
+version: 1.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: v0.5.0
+appVersion: v0.7.0

--- a/charts/akeyless-zero-trust-bastion/README.md
+++ b/charts/akeyless-zero-trust-bastion/README.md
@@ -1,6 +1,6 @@
 # Akeyless Zero Trust Bastion
 
-Akeyless Zero Trust Bastion provides zero trust access to remote resources using Akeyless JIT credentials (dynamic secrets and SSH certificate issuers). 
+Akeyless Zero Trust Bastion provides zero trust access to remote resources using Akeyless JIT credentials (dynamic secrets and SSH certificate issuers).
 
 
 ## Introduction
@@ -13,13 +13,13 @@ This chart bootstraps a Akeyless Zero Trust Bastion deployment on a Kubernetes c
 Currently, when using DB applications (mysql, mongodb, mssql, postgres) via the Zero Trust Bastion, it'll only work properly when using
 load balancer with "sticky" session:
 - Ingress - Make sure to use sticky session annotation, for example `nginx.ingress.kubernetes.io/affinity: "cookie"` in Nginx
-- Cloud Provider LB - Make sure to config the LB to support sticky session, for example is AWS, using ELB:   
+- Cloud Provider LB - Make sure to config the LB to support sticky session, for example is AWS, using ELB:
 https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-sticky-sessions.html
 
 ### Prerequisites
 
 #### Horizonal Auto-Scaling
-Horizontal auto-scaling is based on the HorizonalPodAutoscaler object.  
+Horizontal auto-scaling is based on the HorizonalPodAutoscaler object.
 For it to work properly, Kubernetes metrics server must be installed in the cluster - https://github.com/kubernetes-sigs/metrics-server
 
 ## Get Repo Info
@@ -32,12 +32,12 @@ See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation.
 
 ## Installing the Chart
 
-The `values.yaml` file holds default values, replace the values with the ones from your environment where needed.  
+The `values.yaml` file holds default values, replace the values with the ones from your environment where needed.
 
 To install the chart run:
 ```bash
 helm install RELEASE_NAME helm-charts/akeyless-zero-trust-bastion
-``` 
+```
 
 ## Parameters
 
@@ -48,14 +48,14 @@ The following table lists the configurable parameters of the Zero Trust Bastion 
 | Parameter                                 | Description                                                                                                          | Default                                                      |
 |-------------------------------------------|----------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------|
 | `image.repository`                        | Zero Trust Bastion image name                                                                                        | `akeyless/zero-trust-bastion`                                |
-| `image.tag`                               | Zero Trust Bastion image tag                                                                                         | `latest`                                                     |      
-| `image.pullPolicy`                        | Zero Trust Bastion image pull policy                                                                                 | `Always`                                                     |  
+| `image.tag`                               | Zero Trust Bastion image tag                                                                                         | `latest`                                                     |
+| `image.pullPolicy`                        | Zero Trust Bastion image pull policy                                                                                 | `Always`                                                     |
 | `image.dockerRepositoryCreds`             | Akeyless docker repository credentials                                                                               | `nil`                                                        |
-| `updateStrategy`                          | Updating statefulset strategy                                                                                        | `RollingUpdate`                                              |  
-| `containerName`                           | Zero Trust Bastion container name                                                                                    | `zero-trust-bastion`                                         |  
+| `updateStrategy`                          | Updating statefulset strategy                                                                                        | `RollingUpdate`                                              |
+| `containerName`                           | Zero Trust Bastion container name                                                                                    | `zero-trust-bastion`                                         |
 | `replicaCount`                            | Number of Zero Trust Bastion nodes                                                                                   | `1`                                                          |
-| `livenessProbe`                           | Liveness probe configuration for Zero Trust Bastion                                                                  | Check `values.yaml` file                                     |                   
-| `readinessProbe`                          | Readiness probe configuration for Zero Trust Bastion                                                                 | Check `values.yaml` file                                     |         
+| `livenessProbe`                           | Liveness probe configuration for Zero Trust Bastion                                                                  | Check `values.yaml` file                                     |
+| `readinessProbe`                          | Readiness probe configuration for Zero Trust Bastion                                                                 | Check `values.yaml` file                                     |
 | `resources.limits`                        | The resources limits for Zero Trust Bastion containers                                                               | `{}`                                                         |
 | `resources.requests`                      | The requested resources for Zero Trust Bastion containers                                                            | `{}`                                                         |
 
@@ -72,7 +72,7 @@ The following table lists the configurable parameters of the Zero Trust Bastion 
 | `ingress.hostname`                        | Default host for the ingress resource                                                                                | `zero-trust-bastion.local`                                   |
 | `ingress.annotations`                     | Ingress annotations                                                                                                  | `[]`                                                         |
 | `ingress.tls`                             | Enable TLS configuration for the hostname defined at `ingress.hostname` parameter                                    | `false`                                                      |
-| `ingress.existingSecret`                  | Existing secret for the Ingress TLS certificate                                                                      | `nil`                                                        |  
+| `ingress.existingSecret`                  | Existing secret for the Ingress TLS certificate                                                                      | `nil`                                                        |
 
 ### Zero Trust Bastion configuration parameters
 
@@ -85,7 +85,7 @@ The following table lists the configurable parameters of the Zero Trust Bastion 
 | `config.rdpRecord.s3.awsAccessKeyId`      | AWS Access Key ID, not required if using EC2 IAM roles                                                               | `nil`                                                        |
 | `config.rdpRecord.s3.awsSecretAccessKey`  | AWS Secret Access Key, not required if using EC2 IAM roles                                                           | `nil`                                                        |
 | `config.rdpRecord.existingSecret`         | Specifies an existing secret to be used for bastion, management AWS credentials                                      | `nil`                                                        |
-| `config.privilegedAccess.accessID` | Access ID with "read" capability for privileged access. Supported auth methods: AWS IAM and API Key. | `nil` |
+| `config.privilegedAccess.accessID` | Access ID with "read" capability for privileged access. Supported auth methods: AWS IAM, Azure AD and API Key. | `nil` |
 | `config.privilegedAccess.accessKey` | Access Key with "read" capability for privileged access. Use with privileged accessID of type API Key. | `nil` |
 | `config.privilegedAccess.allowedAccessIDs` | Access will be permitted only to these access IDs. By default, any access ID is accepted. | `[]` |
 | `config.apiGatewayURL` | API Gateway URL to use to fetch the secrets. | `https://rest.akeyless.io` |
@@ -99,4 +99,4 @@ The following table lists the configurable parameters of the Zero Trust Bastion 
 | `HPA.maxReplicas`                         | Minimum desired number of replicas                                                                                   | `14`                                                         |
 | `HPA.cpuAvgUtil`                          | CPU average utilization                                                                                              | `50`                                                         |
 | `HPA.memAvgUtil`                          | Memory average utilization                                                                                           | `50`                                                         |
-                                                                                        
+

--- a/charts/akeyless-zero-trust-bastion/values.yaml
+++ b/charts/akeyless-zero-trust-bastion/values.yaml
@@ -91,8 +91,8 @@ config:
   # end users to only have "list" permissions on Akeyless items if privileged
   # credentials have "read" access.
   privilegedAccess:
-    # supported auth methods: AWS IAM and API Key;
-    # for AWS IAM, provide only accessID;
+    # supported auth methods: AWS IAM, Azure AD and API Key;
+    # for AWS IAM or Azure AD, provide only accessID;
     # for API Key, provide both accessID and accessKey
     accessID: ""
     accessKey: ""


### PR DESCRIPTION
This PR documents that Azure AD privileged credentials are supported in zero trust bastion.