### PR TITLE
Allowing to use existing Secret without setting CustomerFragments

### DIFF
--- a/charts/akeyless-api-gateway/Chart.yaml
+++ b/charts/akeyless-api-gateway/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.2.7
+version: 1.2.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/akeyless-api-gateway/Chart.yaml
+++ b/charts/akeyless-api-gateway/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.2.8
+version: 1.2.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/akeyless-api-gateway/templates/deployment.yaml
+++ b/charts/akeyless-api-gateway/templates/deployment.yaml
@@ -64,7 +64,7 @@ spec:
               path: /status
               port: 18888
 {{- toYaml .Values.readinessProbe | trim | nindent 12 }}
-          {{- if .Values.customerFragments }}
+          {{- if or .Values.customerFragments (and ( hasKey (lookup "v1" "Secret" .Release.Namespace (include "akeyless-api-gw.secretName" .)).data "customer-fragments") .Values.existingSecret) }}
           volumeMounts:
             - name: akeyless-config
               mountPath: /root/.akeyless

--- a/charts/akeyless-api-gateway/templates/deployment.yaml
+++ b/charts/akeyless-api-gateway/templates/deployment.yaml
@@ -15,7 +15,7 @@ spec:
       labels:
         {{- include "akeyless-api-gw.selectorLabels" . | nindent 8 }}
     spec:
-      {{- if .Values.customerFragments }}
+      {{- if or .Values.customerFragments .Values.existingSecret }}
       volumes:
       - name: akeyless-config
         emptyDir: {}

--- a/charts/akeyless-api-gateway/templates/deployment.yaml
+++ b/charts/akeyless-api-gateway/templates/deployment.yaml
@@ -72,28 +72,28 @@ spec:
           resources:
 {{- toYaml .Values.resources | nindent 12 }}
           env:
-          {{- if .Values.akeylessUserAuth.adminAccessId }}
+          {{- if or .Values.akeylessUserAuth.adminAccessId (and ( hasKey (lookup "v1" "Secret" .Release.Namespace (include "akeyless-api-gw.secretName" .)).data "admin-access-id" ) .Values.existingSecret) }}
             - name: ADMIN_ACCESS_ID
               valueFrom:
                 secretKeyRef:
                   name: {{ include "akeyless-api-gw.secretName" . }}
                   key: admin-access-id
           {{- end }}
-          {{- if .Values.akeylessUserAuth.allowedAccessIDs }}
+          {{- if or .Values.akeylessUserAuth.allowedAccessIDs (and ( hasKey (lookup "v1" "Secret" .Release.Namespace (include "akeyless-api-gw.secretName" .)).data "allowed-access-ids") .Values.existingSecret) }}
             - name: ALLOWED_ACCESS_IDS
               valueFrom:
                 secretKeyRef:
                   name: {{ include "akeyless-api-gw.secretName" . }}
                   key: allowed-access-ids
           {{- end }}
-          {{- if .Values.akeylessUserAuth.adminAccessKey }}
+          {{- if or .Values.akeylessUserAuth.adminAccessKey (and ( hasKey (lookup "v1" "Secret" .Release.Namespace (include "akeyless-api-gw.secretName" .)).data "admin-access-key") .Values.existingSecret) }}
             - name: ADMIN_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ include "akeyless-api-gw.secretName" . }}
                   key: admin-access-key
           {{- end }}
-          {{- if .Values.akeylessUserAuth.adminPassword }}
+          {{- if or .Values.akeylessUserAuth.adminPassword (and ( hasKey (lookup "v1" "Secret" .Release.Namespace (include "akeyless-api-gw.secretName" .)).data "admin-password") .Values.existingSecret) }}
             - name: ADMIN_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/akeyless-api-gateway/templates/deployment.yaml
+++ b/charts/akeyless-api-gateway/templates/deployment.yaml
@@ -15,7 +15,7 @@ spec:
       labels:
         {{- include "akeyless-api-gw.selectorLabels" . | nindent 8 }}
     spec:
-      {{- if or .Values.customerFragments .Values.existingSecret }}
+      {{- if or .Values.customerFragments (and ( hasKey (lookup "v1" "Secret" .Release.Namespace (include "akeyless-api-gw.secretName" .)).data "customer-fragments") .Values.existingSecret) }}
       volumes:
       - name: akeyless-config
         emptyDir: {}


### PR DESCRIPTION
When deploying the gateway using the existing secret, it was still necessary to add something to the customerFragments value.
This PR adds the capability of adding volumes without needing to set the customerFragments value.