### PR TITLE
bugfix/ingress_secret_tls - ingress tls secret use wrong hostname

### DIFF
--- a/charts/akeyless-api-gateway/Chart.yaml
+++ b/charts/akeyless-api-gateway/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.3.0
+version: 1.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.20.1
+appVersion: 2.20.0

--- a/charts/akeyless-api-gateway/Chart.yaml
+++ b/charts/akeyless-api-gateway/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.20.0
+appVersion: 2.20.1

--- a/charts/akeyless-api-gateway/templates/_helpers.tpl
+++ b/charts/akeyless-api-gateway/templates/_helpers.tpl
@@ -66,10 +66,10 @@ Create the name of the service account to use
 Get the Ingress TLS secret.
 */}}
 {{- define "akeyless-api-gw.ingressSecretTLSName" -}}
-    {{- if .Values.ingress.existingSecret -}}
-        {{- printf "%s" .Values.ingress.existingSecret -}}
+    {{- if .existingSecret -}}
+        {{- printf "%s" .existingSecret -}}
     {{- else -}}
-        {{- printf "%s-tls" .Values.ingress.hostname -}}
+        {{- printf "%s-tls" .hostname -}}
     {{- end -}}
 {{- end -}}
 

--- a/charts/akeyless-api-gateway/templates/deployment.yaml
+++ b/charts/akeyless-api-gateway/templates/deployment.yaml
@@ -58,13 +58,13 @@ spec:
             {{- end }}
           livenessProbe:
             httpGet:
-              path: /status
-              port: 18888
+              path: /
+              port: 8080
 {{- toYaml .Values.livenessProbe | trim | nindent 12 }}
           readinessProbe:
             httpGet:
-              path: /status
-              port: 18888
+              path: /
+              port: 8080
 {{- toYaml .Values.readinessProbe | trim | nindent 12 }}
           {{- if eq (include "akeyless-api-gw.customerFragmentExist" .) "true" }}
           volumeMounts:

--- a/charts/akeyless-api-gateway/templates/ingress.yaml
+++ b/charts/akeyless-api-gateway/templates/ingress.yaml
@@ -31,7 +31,8 @@ spec:
     - hosts:
       - {{ .hostname }}
       {{- if $.Values.ingress.certManager }}
-      secretName: {{ template "akeyless-api-gw.ingressSecretTLSName" $ }}
+      {{$data := dict "hostname" .hostname "existingSecret" $.Values.ingress.existingSecret}}
+      secretName: {{ include "akeyless-api-gw.ingressSecretTLSName" $data }}
       {{- end }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
Ingress tls secret was issued wrong hostname.

Expected:
if you added the following hostnames under ingress:
```
- ui.gateway.local
- hvp.gateway.local
```

the chart will generate the following:
```
tls:
    - hosts:
      - ui.gateway.local
      secretName: ui.gateway.local-tls
    - hosts:
      - hvp.gateway.local
      secretName: hvp.gateway.local-tls
```      