### PR TITLE
SRA HPA Validation and Ingress API version

### DIFF
--- a/charts/akeyless-secure-remote-access/Chart.yaml
+++ b/charts/akeyless-secure-remote-access/Chart.yaml
@@ -13,11 +13,11 @@ description: A Helm chart for Kubernetes akeyless-zero-trust-bastion and akeyles
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.10.3
+version: 0.10.4
 
-appVersion: v0.10.1_0.11.34
+appVersion: v0.10.2_0.11.34
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 annotations:
-  ztbVersion: v0.10.1
+  ztbVersion: v0.10.2
   sshVersion: 0.11.34

--- a/charts/akeyless-secure-remote-access/Chart.yaml
+++ b/charts/akeyless-secure-remote-access/Chart.yaml
@@ -13,7 +13,7 @@ description: A Helm chart for Kubernetes akeyless-zero-trust-bastion and akeyles
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.10.4
+version: 0.10.5
 
 appVersion: v0.10.2_0.11.34
 # This is the version number of the application being deployed. This version number should be

--- a/charts/akeyless-secure-remote-access/README.md
+++ b/charts/akeyless-secure-remote-access/README.md
@@ -168,6 +168,7 @@ The following table lists the configurable parameters of the SSH Bastion chart a
 
 
 ### HPA parameters
+#### Enable only when using a shared persistent storage!
 
 | Parameter                                 | Description                                                                                                          | Default                                                      |
 |-------------------------------------------|----------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------|

--- a/charts/akeyless-secure-remote-access/templates/_helpers.tpl
+++ b/charts/akeyless-secure-remote-access/templates/_helpers.tpl
@@ -72,3 +72,28 @@ Generate chart secret name
 {{- define "akeyless-zero-trust-bastion.secretName" -}}
 {{ default (include "akeyless-secure-remote-access.fullname" .) .Values.ztbConfig.config.rdpRecord.existingSecret }}
 {{- end -}}
+
+{{/*
+Checks kubernetes API version support for ingress BC
+*/}}
+{{- define "checkIngressVersion.ingress.apiVersion" -}}
+  {{- if and (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (semverCompare ">= 1.19.x" .Capabilities.KubeVersion.Version) -}}
+      {{- print "networking.k8s.io/v1" -}}
+  {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Checks persistent volume
+*/}}
+{{- define "checkPersistenceVolume" -}}
+  {{ range .Values.sshConfig.persistence.volumes }}
+    {{- $used := .name -}}
+    {{- if $used }}
+      {{- printf "true" }}
+    {{- end }}  
+  {{- end }}
+{{- end }}

--- a/charts/akeyless-secure-remote-access/templates/horizontalPodAutoscaler.yaml
+++ b/charts/akeyless-secure-remote-access/templates/horizontalPodAutoscaler.yaml
@@ -1,5 +1,8 @@
 {{- if eq .Values.sshConfig.enabled true }}
 {{- if .Values.sshConfig.HPA.enabled }}
+{{- if ne (include "checkPersistenceVolume" .) "true" }}
+  {{ fail "ERROR - Cannot enable HPA without defining a shared persistent storage volume" }}
+{{- end }}
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/akeyless-secure-remote-access/templates/ingress.yaml
+++ b/charts/akeyless-secure-remote-access/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if eq .Values.ztbConfig.enabled true }}
 {{- if .Values.ztbConfig.ingress.enabled }}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: {{ include "checkIngressVersion.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ include "akeyless-secure-remote-access.fullname" . }}
@@ -21,9 +21,18 @@ spec:
     http:
       paths:
       - path: {{ .Values.ztbConfig.ingress.path }}
+{{- if eq (include "checkIngressVersion.ingress.apiVersion" . ) "networking.k8s.io/v1" }}
+        pathType: ImplementationSpecific
+        backend:
+         service:
+          name: web-{{ include "akeyless-secure-remote-access.fullname" . }}
+          port:
+            name: api
+{{- else }}
         backend:
          serviceName: web-{{ include "akeyless-secure-remote-access.fullname" . }}
          servicePort: api
+{{- end }}
 {{- end }}
 {{- if .Values.ztbConfig.ingress.tls }}
   tls:

--- a/charts/akeyless-secure-remote-access/templates/statefulSet.yaml
+++ b/charts/akeyless-secure-remote-access/templates/statefulSet.yaml
@@ -8,9 +8,7 @@ metadata:
     {{- include "akeyless-secure-remote-access.labels" . | nindent 4 }}
 spec:
   serviceName: {{ include "akeyless-secure-remote-access.fullname" . }}
-  {{- if not .Values.sshConfig.HPA.enabled }}
-  replicas: {{ .Values.sshConfig.replicaCount }}
-  {{- end }}
+  replicas: 1
   updateStrategy:
     type: {{ .Values.sshConfig.updateStrategy }}
   selector:

--- a/charts/akeyless-secure-remote-access/values.yaml
+++ b/charts/akeyless-secure-remote-access/values.yaml
@@ -214,8 +214,8 @@ sshConfig:
     timeoutSeconds: 5
 
   HPA:
-    # Set the below to false in case you do not want to add Horizontal Pod AutoScaling to the StatefulSet (not recommended)
-    enabled: true
+    # Set the below to true only when using a shared persistent storage (defined at .persistence.volumes) 
+    enabled: false
     minReplicas: 1
     maxReplicas: 14
     cpuAvgUtil: 50

--- a/charts/akeyless-secure-remote-access/values.yaml
+++ b/charts/akeyless-secure-remote-access/values.yaml
@@ -154,7 +154,6 @@ ztbConfig:
 sshConfig:
 # Enable akeyless-ssh-bastion. Valid values: true/false.
   enabled: true
-  replicaCount: 1
 
   ## Statefulsets rolling update update strategy
   ## Ref: https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#rolling-update

--- a/charts/akeyless-zero-trust-bastion/Chart.yaml
+++ b/charts/akeyless-zero-trust-bastion/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.3.1
+version: 1.3.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: v0.10.1
+appVersion: v0.10.2


### PR DESCRIPTION
- Get the compatible k8s ingress API version ("networking.k8s.io/v1beta1" deprecated at k8s v1.22
- Enable HPA for ssh-bastion (SRA) only if a shared PV is defined
