### PR TITLE
BC for K8s Ingress API version

### DIFF
--- a/charts/akeyless-api-gateway/Chart.yaml
+++ b/charts/akeyless-api-gateway/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.8.2
+version: 1.8.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 3.4.1
+appVersion: 3.5.0

--- a/charts/akeyless-api-gateway/Chart.yaml
+++ b/charts/akeyless-api-gateway/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.8.1
+version: 1.8.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/akeyless-api-gateway/templates/_helpers.tpl
+++ b/charts/akeyless-api-gateway/templates/_helpers.tpl
@@ -208,3 +208,16 @@ Check logand conf
         {{- printf "false" -}}
     {{- end -}}
 {{- end -}}
+
+{{/*
+Checks kubernetes API version support for ingress BC
+*/}}
+{{- define "checkIngressVersion.ingress.apiVersion" -}}
+  {{- if and (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (semverCompare ">= 1.19.x" .Capabilities.KubeVersion.Version) -}}
+      {{- print "networking.k8s.io/v1" -}}
+  {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}

--- a/charts/akeyless-api-gateway/templates/ingress.yaml
+++ b/charts/akeyless-api-gateway/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled }}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: {{ include "checkIngressVersion.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ include "akeyless-api-gw.fullname" . }}
@@ -20,11 +20,19 @@ spec:
     http:
       paths:
       - path: {{ $.Values.ingress.path }}
+{{- if eq (include "checkIngressVersion.ingress.apiVersion" $ ) "networking.k8s.io/v1" }}
+        pathType: ImplementationSpecific
+        backend:
+         service:
+          name: {{ include "akeyless-api-gw.fullname" $ }}
+          port:
+            name: {{ .servicePort }}
+{{- else }}
         backend:
          serviceName: {{ include "akeyless-api-gw.fullname" $ }}
          servicePort: {{ .servicePort }}
 {{- end }}
-
+{{- end }}
 {{- if $.Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.rules }}

--- a/charts/akeyless-zero-trust-bastion/Chart.yaml
+++ b/charts/akeyless-zero-trust-bastion/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.3.2
+version: 1.3.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/akeyless-zero-trust-bastion/templates/_helpers.tpl
+++ b/charts/akeyless-zero-trust-bastion/templates/_helpers.tpl
@@ -68,3 +68,16 @@ Generate chart secret name
 {{- define "akeyless-zero-trust-bastion.secretName" -}}
 {{ default (include "akeyless-zero-trust-bastion.fullname" .) .Values.config.rdpRecord.existingSecret }}
 {{- end -}}
+
+{{/*
+Checks kubernetes API version support for ingress BC
+*/}}
+{{- define "checkIngressVersion.ingress.apiVersion" -}}
+  {{- if and (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (semverCompare ">= 1.19.x" .Capabilities.KubeVersion.Version) -}}
+      {{- print "networking.k8s.io/v1" -}}
+  {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}

--- a/charts/akeyless-zero-trust-bastion/templates/ingress.yaml
+++ b/charts/akeyless-zero-trust-bastion/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled }}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: {{ include "checkIngressVersion.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ include "akeyless-zero-trust-bastion.fullname" . }}
@@ -20,9 +20,18 @@ spec:
     http:
       paths:
       - path: {{ .Values.ingress.path }}
+{{- if eq (include "checkIngressVersion.ingress.apiVersion" . ) "networking.k8s.io/v1" }}
+        pathType: ImplementationSpecific
+        backend:
+         service:
+          name: {{ include "akeyless-zero-trust-bastion.fullname" . }}-svc
+          port:
+            name: api
+{{- else }}
         backend:
          serviceName: {{ include "akeyless-zero-trust-bastion.fullname" . }}-svc
          servicePort: api
+{{- end }}
 {{- end }}
 {{- if .Values.ingress.tls }}
   tls:

--- a/charts/akeyless-zero-trust-web-access/Chart.yaml
+++ b/charts/akeyless-zero-trust-web-access/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.1.42
+version: 1.1.43
 appVersion: 0.11.54
 icon: https://akeylesslabs.github.io/helm-charts/assets/logo/akl.jpeg
 home: https://www.akeyless.io

--- a/charts/akeyless-zero-trust-web-access/Chart.yaml
+++ b/charts/akeyless-zero-trust-web-access/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.1.43
-appVersion: 0.11.54
+version: 1.1.44
+appVersion: 0.11.55
 icon: https://akeylesslabs.github.io/helm-charts/assets/logo/akl.jpeg
 home: https://www.akeyless.io
 sources:

--- a/charts/akeyless-zero-trust-web-access/templates/_helpers.tpl
+++ b/charts/akeyless-zero-trust-web-access/templates/_helpers.tpl
@@ -72,3 +72,16 @@ Get the Ingress TLS secret.
         {{- printf "%s-tls" .Values.dispatcher.ingress.hostname -}}
     {{- end -}}
 {{- end -}}
+
+{{/*
+Checks kubernetes API version support for ingress BC
+*/}}
+{{- define "checkIngressVersion.ingress.apiVersion" -}}
+  {{- if and (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (semverCompare ">= 1.19.x" .Capabilities.KubeVersion.Version) -}}
+      {{- print "networking.k8s.io/v1" -}}
+  {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}

--- a/charts/akeyless-zero-trust-web-access/templates/ingress.yaml
+++ b/charts/akeyless-zero-trust-web-access/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.dispatcher.ingress.enabled }}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: {{ include "checkIngressVersion.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ include "akeyless-zero-web-access.fullname" . }}
@@ -20,9 +20,18 @@ spec:
     http:
       paths:
       - path: {{ .Values.dispatcher.ingress.path }}
+{{- if eq (include "checkIngressVersion.ingress.apiVersion" . ) "networking.k8s.io/v1" }}
+        pathType: ImplementationSpecific
+        backend:
+         service:
+          name: {{ include "akeyless-zero-web-access.fullname" . }}-dispatcher
+          port:
+            name: http
+{{- else }}
         backend:
          serviceName: {{ include "akeyless-zero-web-access.fullname" . }}-dispatcher
          servicePort: http
+{{- end }}
 {{- end }}
 {{- if .Values.dispatcher.ingress.tls }}
   tls:


### PR DESCRIPTION
Added backwards compatibility for k8s ingress API version for the following helm charts:

-  Akeyless Api-gw
-  Akeyless zero trust bastion
-  Akeyless zero trust web access

as a part of [this ticket](https://akeyless.atlassian.net/browse/ASM-2773?focusedCommentId=10991&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-10991)