### PR TITLE
updated the helm install command for akeyless-secure-remote-access

### DIFF
--- a/charts/akeyless-secure-remote-access/Chart.yaml
+++ b/charts/akeyless-secure-remote-access/Chart.yaml
@@ -13,7 +13,7 @@ description: A Helm chart for Kubernetes akeyless-zero-trust-bastion and akeyles
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.12.8
+version: 0.12.9
 
 appVersion: v0.13.0_0.11.38
 # This is the version number of the application being deployed. This version number should be

--- a/charts/akeyless-secure-remote-access/README.md
+++ b/charts/akeyless-secure-remote-access/README.md
@@ -47,7 +47,7 @@ The `values.yaml` file holds default values, replace the values with the ones fr
 
 To install the chart run:
 ```bash
-helm install RELEASE_NAME helm-charts/akeyless-secure-remote-access
+helm install RELEASE_NAME akeyless/akeyless-sra -f values.yaml
 ```
 ## Global Parameters
 


### PR DESCRIPTION
The instruction to install the helm chart in the readme file is incorrect.
  helm install RELEASE_NAME helm-charts/akeyless-secure-remote-access

The correct command to install the chart from docs site:
  helm install <RELEASE NAME> akeyless/akeyless-sra -f values.yaml