### PR TITLE
add scheme when enable TLS terminating at gateway

### DIFF
--- a/charts/akeyless-api-gateway/Chart.yaml
+++ b/charts/akeyless-api-gateway/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.11.5
+version: 1.11.6
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/akeyless-api-gateway/Chart.yaml
+++ b/charts/akeyless-api-gateway/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.11.6
+version: 1.12.1
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/akeyless-api-gateway/templates/deployment.yaml
+++ b/charts/akeyless-api-gateway/templates/deployment.yaml
@@ -123,11 +123,17 @@ spec:
             httpGet:
               path: /
               port: 8080
+              {{- if .Values.TLSConf.akeylessAPIServices }}
+              scheme: HTTPS
+              {{- end }}
 {{- toYaml .Values.livenessProbe | trim | nindent 12 }}
           readinessProbe:
             httpGet:
               path: /
               port: 8080
+              {{- if .Values.TLSConf.akeylessAPIServices }}
+              scheme: HTTPS
+              {{- end }}
 {{- toYaml .Values.readinessProbe | trim | nindent 12 }}
          {{- if or (eq (include "akeyless-api-gw.customerFragmentExist" .) "true") (eq (include "akeyless-api-gw.logandConfExist" .) "true") (eq (include "akeyless-api-gw.tlsCertificateExist" .) "true")}}
           volumeMounts:


### PR DESCRIPTION
When choosing to terminate TLS at the gateway endpoint, the readiness and liveness probes should use the correct scheme