### PR TITLE
feature/asm-3644_ingress - support ingressClassName field in ingress

### DIFF
--- a/charts/akeyless-api-gateway/Chart.yaml
+++ b/charts/akeyless-api-gateway/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.14.2
+version: 1.15.2
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/akeyless-api-gateway/README.md
+++ b/charts/akeyless-api-gateway/README.md
@@ -53,17 +53,18 @@ The following table lists the configurable parameters of the API Gateway chart a
 
 ### Exposure parameters
 
-| Parameter                                 | Description                                                                                                          | Default                                                      |
-|-------------------------------------------|----------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------|
-| `service.type`                            | Kubernetes service type                                                                                              | `LoadBalancer`                                               |
-| `service.ports`                           | Service ports object, look at the comments for examples                                                              | Check `values.yaml` file                                     |
-| `service.annotations`                     | Service extra annotations                                                                                            | `{}`                                                         |
-| `ingress.enabled`                         | Enable ingress resource                                                                                              | `false`                                                      |
-| `ingress.annotations`                     | Ingress annotations                                                                                                  | `[]`                                                         |
-| `ingress.rules`                           | Ingress rules object, look at the comments for examples                                                              | Check `values.yaml` file                                     |
-| `ingress.path`                            | Path for the default host                                                                                            | `/`                                                          |
-| `ingress.tls`                             | Enable TLS configuration for the hostname                                                                            | `false`                                                      |
-| `ingress.certManager`                     | Add annotations for cert-manager                                                                                     | `false`                                                      |
+| Parameter                                 | Description                                                                                                          | Default                  |
+|-------------------------------------------|----------------------------------------------------------------------------------------------------------------------|--------------------------|
+| `service.type`                            | Kubernetes service type                                                                                              | `LoadBalancer`           |
+| `service.ports`                           | Service ports object, look at the comments for examples                                                              | Check `values.yaml` file |
+| `service.annotations`                     | Service extra annotations                                                                                            | `{}`                     |
+| `ingress.enabled`                         | Enable ingress resource                                                                                              | `false`                  |
+| `ingress.ingressClassName`                | A reference to an IngressClass resource                                                                              | `nil`                    |
+| `ingress.annotations`                     | Ingress annotations                                                                                                  | `[]`                     |
+| `ingress.rules`                           | Ingress rules object, look at the comments for examples                                                              | Check `values.yaml` file |
+| `ingress.path`                            | Path for the default host                                                                                            | `/`                      |
+| `ingress.tls`                             | Enable TLS configuration for the hostname                                                                            | `false`                  |
+| `ingress.certManager`                     | Add annotations for cert-manager                                                                                     | `false`                  |
 
 ### HPA parameters
 

--- a/charts/akeyless-api-gateway/templates/ingress.yaml
+++ b/charts/akeyless-api-gateway/templates/ingress.yaml
@@ -17,6 +17,9 @@ metadata:
 {{ toYaml .Values.ingress.annotations | indent 4 }}
 {{- end }}
 spec:
+{{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+{{- end }}
   rules:
 {{- range .Values.ingress.rules }}
   - host: {{ .hostname }}

--- a/charts/akeyless-api-gateway/values.yaml
+++ b/charts/akeyless-api-gateway/values.yaml
@@ -94,8 +94,13 @@ ingress:
   ##
   enabled: false
 
-  annotations: {}
+  ## A reference to an IngressClass resource
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation
+
+#  ingressClassName:
+
   labels: {}
+
   # Example for Nginx ingress
   #    annotations:
   #      kubernetes.io/ingress.class: nginx
@@ -110,6 +115,8 @@ ingress:
   #    annotations:
   #      kubernetes.io/ingress.class: alb
   #      alb.ingress.kubernetes.io/scheme: internet-facing
+  annotations: {}
+
 
   rules:
     - servicePort: web


### PR DESCRIPTION
Support an IngressClass cluster resource named `IngressClassName`
https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation