### PR TITLE
ASM-3912-add-support-for-node-affinity-in-api-gateway-helm-chart

### DIFF
--- a/charts/akeyless-api-gateway/Chart.yaml
+++ b/charts/akeyless-api-gateway/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.16.0
+version: 1.16.1
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/akeyless-api-gateway/Chart.yaml
+++ b/charts/akeyless-api-gateway/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.16.1
+version: 1.16.3
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/akeyless-api-gateway/templates/deployment.yaml
+++ b/charts/akeyless-api-gateway/templates/deployment.yaml
@@ -109,6 +109,10 @@ spec:
               mountPath: /tls_conf
           {{- end}}
       {{- end }} #spec
+      {{- if .Values.deployment.affinety }}
+      affinity:
+      {{ toYaml .Values.deployment.affinety | indent 4 }}
+      {{- end }}
       containers:
         - name: {{ .Values.containerName }}
           {{- if .Values.akeylessStrictMode  }}

--- a/charts/akeyless-api-gateway/templates/deployment.yaml
+++ b/charts/akeyless-api-gateway/templates/deployment.yaml
@@ -26,6 +26,10 @@ spec:
           {{- toYaml .Values.deployment.labels | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.deployment.affinity.enabled }}
+      affinity:
+      {{- toYaml .Values.deployment.affinity.data | nindent 8 }}
+      {{- end }}
       {{- if .Values.deployment.securityContext }}
         {{- if .Values.deployment.securityContext.enabled }}
       securityContext:
@@ -109,10 +113,6 @@ spec:
               mountPath: /tls_conf
           {{- end}}
       {{- end }} #spec
-      {{- if .Values.deployment.affinety }}
-      affinity:
-      {{ toYaml .Values.deployment.affinety | indent 4 }}
-      {{- end }}
       containers:
         - name: {{ .Values.containerName }}
           {{- if .Values.akeylessStrictMode  }}

--- a/charts/akeyless-api-gateway/values.yaml
+++ b/charts/akeyless-api-gateway/values.yaml
@@ -34,7 +34,17 @@ deployment:
     annotations:
   #      iam.gke.io/gcp-service-account: change_me_to_gcp_service_account
   #      eks.amazonaws.com/role-arn: arn:aws:iam::40XXXXXXXX75:role/eksctl-Role1-XXXXXXXX
-  affinety:
+  affinity:
+    enabled: false
+    data:
+  #    nodeAffinity:
+  #      requiredDuringSchedulingIgnoredDuringExecution:
+  #        nodeSelectorTerms:
+  #          - matchExpressions:
+  #              - key: kubernetes.io/arch
+  #                operator: In
+  #                values:
+  #                  - amd64
   # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
   nodeSelector:
     #     iam.gke.io/gke-metadata-server-enabled: "true"

--- a/charts/akeyless-api-gateway/values.yaml
+++ b/charts/akeyless-api-gateway/values.yaml
@@ -34,6 +34,8 @@ deployment:
     annotations:
   #      iam.gke.io/gcp-service-account: change_me_to_gcp_service_account
   #      eks.amazonaws.com/role-arn: arn:aws:iam::40XXXXXXXX75:role/eksctl-Role1-XXXXXXXX
+  affinety:
+  # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
   nodeSelector:
     #     iam.gke.io/gke-metadata-server-enabled: "true"
 


### PR DESCRIPTION
Add support for nodeAffinity in API gateway Helm chart.
added affinity to api gw deployment to enable nodeAffinity and more