### PR TITLE
feature/asm-4189 - support exists secret for splunk config

### DIFF
--- a/charts/akeyless-api-gateway/templates/_helpers.tpl
+++ b/charts/akeyless-api-gateway/templates/_helpers.tpl
@@ -96,6 +96,14 @@ Generate chart secret name
     {{- end -}}
 {{- end -}}
 
+{{- define "akeyless-api-gw.logandSecretName" -}}
+    {{- if .Values.logandExistingSecretName -}}
+        {{- printf "%s" .Values.logandExistingSecretName -}}
+    {{- else -}}
+        logand-conf
+    {{- end -}}
+{{- end -}}
+
 {{- define "akeyless-api-gw.cacheSecretName" -}}
         {{ $.Release.Name }}-cache-secret
 {{- end -}}
@@ -206,7 +214,7 @@ Check admin password
 Check logand conf
 */}}
 {{- define "akeyless-api-gw.logandConfExist" -}}
-    {{- if .Values.logandConf -}}
+    {{- if  or .Values.logandConf .Values.logandExistingSecretName -}}
         {{- printf "true" -}}
     {{- else -}}
         {{- printf "false" -}}

--- a/charts/akeyless-api-gateway/templates/deployment.yaml
+++ b/charts/akeyless-api-gateway/templates/deployment.yaml
@@ -57,7 +57,7 @@ spec:
       {{- if eq (include "akeyless-api-gw.logandConfExist" .) "true"}}
       - name: logand-conf
         secret:
-          secretName: logand-conf
+          secretName: {{ include "akeyless-api-gw.logandSecretName" . }}
           items:
             - key: logand-conf
               path: logand.conf

--- a/charts/akeyless-api-gateway/values.yaml
+++ b/charts/akeyless-api-gateway/values.yaml
@@ -295,15 +295,19 @@ metrics:
 ## Specifies an initial configuration for log forwarding
 # for more details: https://docs.akeyless.io/docs/ssh-log-forwarding
 #
-# logandConf: |
-#   enable="true"
-#   target_log_type="splunk" #splunk/syslog/logstash/elasticsearch/logz_io/aws_s3/azure_log_analytics/datadog
-#   target_splunk_sourcetype="<your_sourcetype>"
-#   target_splunk_source="<your_source>"
-#   target_splunk_index="<your_index>"
-#   target_splunk_token="<your_token>"
-#   target_splunk_url="<your_splunk_host_address>"
+#logandConf: |
+# enable="true"
+# target_log_type="splunk" #splunk/syslog/logstash/elasticsearch/logz_io/aws_s3/azure_log_analytics/datadog
+# target_splunk_sourcetype="<your_sourcetype>"
+# target_splunk_source="<your_source>"
+# target_splunk_index="<your_index>"
+# target_splunk_token="<your_token>"
+# target_splunk_url="<your_splunk_host_address>"
 
+
+# Specifies an existing secret for logand should be in yaml syntax, and include:
+# - logand-conf field (base64). The content the same as above.
+logandExistingSecretName:
 
 
 


### PR DESCRIPTION
Mechanism to pull Splunk token value from secure location:

Support the usage of exists secret for logand configuration
