### PR TITLE
validate only charts

### DIFF
--- a/.github/workflows/clear_validation_status.yaml
+++ b/.github/workflows/clear_validation_status.yaml
@@ -1,0 +1,13 @@
+name: Validate Chart Version
+
+on:
+  deployment:
+  pull_request:
+    paths-ignore:
+      - "charts/**"
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+      - run: 'echo "No validate status check required"'

--- a/.github/workflows/validate_chart_release.yaml
+++ b/.github/workflows/validate_chart_release.yaml
@@ -3,6 +3,8 @@ name: Validate Chart Version
 on:
   deployment:
   pull_request:
+    paths:
+      - "charts/**"
 
 jobs:
   validate:


### PR DESCRIPTION
This PR will scope the validation to only files committed to the `scripts` directory
- committing to a README.md should no longer require running a helm-lint
- committing to the manifests directory should no longer require running a helm-lint

[Relevant documentation](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#example)