### PR TITLE
Add another way to deploy customer fragments

### DIFF
--- a/charts/akeyless-api-gateway/Chart.yaml
+++ b/charts/akeyless-api-gateway/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.19.2
+version: 1.19.3
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/akeyless-api-gateway/templates/secrets.yaml
+++ b/charts/akeyless-api-gateway/templates/secrets.yaml
@@ -28,7 +28,6 @@ data:
 {{- end }}
 {{- if .Values.customerFragments }}
   customer-fragments: {{ .Values.customerFragments | b64enc | quote }}
-{{- end }}
 {{- else if .Values.customerFragmentsEncoded }}
   customer-fragments: {{ .Values.customerFragmentsEncoded | quote }}
 {{- end }}

--- a/charts/akeyless-api-gateway/templates/secrets.yaml
+++ b/charts/akeyless-api-gateway/templates/secrets.yaml
@@ -29,6 +29,9 @@ data:
 {{- if .Values.customerFragments }}
   customer-fragments: {{ .Values.customerFragments | b64enc | quote }}
 {{- end }}
+{{- else if .Values.customerFragmentsEncoded }}
+  customer-fragments: {{ .Values.customerFragmentsEncoded | quote }}
+{{- end }}
 {{- end }}
 
 

--- a/charts/akeyless-api-gateway/values.yaml
+++ b/charts/akeyless-api-gateway/values.yaml
@@ -224,6 +224,12 @@ universalIdentity:
 # For more information: https://docs.akeyless.io/docs/implement-zero-knowledge
 #customerFragments: |
 
+# Customer Fragment that will be in use instead of the regular value, in base64 because of formatting issues.
+# Use this in case you deploy the chart using Terraform.
+#
+# Use only one of the values!
+#customerFragmentsEncoded: "BASE64 String"
+
 # Specifies an existing secret to be used for API Gateway, must include:
 #  - admin-access-id,
 #  - admin-access-key


### PR DESCRIPTION
Adding customer fragments as base64 encoded string, is more viable in the usecase of deploying this helm using terraform