### PR TITLE
Added support to pull from Google artifact registry

### DIFF
--- a/charts/akeyless-api-gateway/Chart.yaml
+++ b/charts/akeyless-api-gateway/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.23.0
+version: 1.23.1
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/akeyless-api-gateway/templates/_helpers.tpl
+++ b/charts/akeyless-api-gateway/templates/_helpers.tpl
@@ -345,10 +345,10 @@ Check metrics configuration Secret
     {{- end -}}
 {{- end -}}
 
-{{- define "gcp_artifacts_registry" -}}
-    {{- if .Values.image.gcp_artifact_registry.enabled }}
-        {{- printf "%s/" (.Values.image.gcp_artifact_registry.repository | trimSuffix "/") }}
+{{- define "docker_repository" -}}
+    {{- if .Values.image.dockerhub_cache.enabled }}
+        {{- printf "%s/%s" (.Values.image.dockerhub_cache.repository | trimSuffix "/") (.Values.image.repository | trimPrefix "akeyless/")}}
     {{- else -}}
-        {{- print ""}}
+        {{ .Values.image.repository }}
     {{- end -}}
 {{- end -}}

--- a/charts/akeyless-api-gateway/templates/_helpers.tpl
+++ b/charts/akeyless-api-gateway/templates/_helpers.tpl
@@ -346,8 +346,8 @@ Check metrics configuration Secret
 {{- end -}}
 
 {{- define "gcp_artifacts_registry" -}}
-    {{- if .Values.image.gcp_registry }}
-        {{- printf "%s/" (.Values.image.gcp_registry | trimSuffix "/") }}
+    {{- if .Values.image.gcp_artifact_registry.enabled }}
+        {{- printf "%s/" (.Values.image.gcp_artifact_registry.repository | trimSuffix "/") }}
     {{- else -}}
         {{- print ""}}
     {{- end -}}

--- a/charts/akeyless-api-gateway/templates/_helpers.tpl
+++ b/charts/akeyless-api-gateway/templates/_helpers.tpl
@@ -344,3 +344,11 @@ Check metrics configuration Secret
         {{- printf "false" -}}
     {{- end -}}
 {{- end -}}
+
+{{- define "gcp_artifacts_registry" -}}
+    {{- if .Values.image.gcp_registry }}
+        {{- printf "%s/" (.Values.image.gcp_registry | trimSuffix "/") }}
+    {{- else -}}
+        {{- print ""}}
+    {{- end -}}
+{{- end -}}

--- a/charts/akeyless-api-gateway/templates/deployment.yaml
+++ b/charts/akeyless-api-gateway/templates/deployment.yaml
@@ -122,9 +122,9 @@ spec:
       containers:
         - name: {{ .Values.containerName }}
           {{- if .Values.akeylessStrictMode  }}
-          image: "{{ template "gcp_artifacts_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}-akeyless"
+          image: "{{ template "docker_repository" . }}:{{ .Values.image.tag }}-akeyless"
           {{else}}
-          image: "{{ template "gcp_artifacts_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ template "docker_repository" . }}:{{ .Values.image.tag }}"
           {{end}}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:

--- a/charts/akeyless-api-gateway/templates/deployment.yaml
+++ b/charts/akeyless-api-gateway/templates/deployment.yaml
@@ -122,9 +122,9 @@ spec:
       containers:
         - name: {{ .Values.containerName }}
           {{- if .Values.akeylessStrictMode  }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}-akeyless"
+          image: "{{ template "gcp_artifacts_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}-akeyless"
           {{else}}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ template "gcp_artifacts_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           {{end}}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:

--- a/charts/akeyless-api-gateway/values.yaml
+++ b/charts/akeyless-api-gateway/values.yaml
@@ -17,7 +17,9 @@ cache:
     pullPolicy: Always
 
 image:
-  gcp_registry: us-docker.pkg.dev/global-production-332815/dockerhub
+  gcp_artifact_registry:
+    enabled: false
+    repository: us-docker.pkg.dev/global-production-332815/dockerhub
   repository: akeyless/base
   pullPolicy: Always
   tag: latest

--- a/charts/akeyless-api-gateway/values.yaml
+++ b/charts/akeyless-api-gateway/values.yaml
@@ -17,9 +17,9 @@ cache:
     pullPolicy: Always
 
 image:
-  gcp_artifact_registry:
+  dockerhub_cache:
     enabled: false
-    repository: us-docker.pkg.dev/global-production-332815/dockerhub
+    repository: docker.akeyless.io
   repository: akeyless/base
   pullPolicy: Always
   tag: latest

--- a/charts/akeyless-api-gateway/values.yaml
+++ b/charts/akeyless-api-gateway/values.yaml
@@ -17,6 +17,7 @@ cache:
     pullPolicy: Always
 
 image:
+  gcp_registry: us-docker.pkg.dev/global-production-332815/dockerhub
   repository: akeyless/base
   pullPolicy: Always
   tag: latest

--- a/charts/akeyless-k8s-secrets-injection/Chart.yaml
+++ b/charts/akeyless-k8s-secrets-injection/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.2.27
+version: 1.2.28
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/akeyless-k8s-secrets-injection/Chart.yaml
+++ b/charts/akeyless-k8s-secrets-injection/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.2.28
+version: 1.2.29
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/akeyless-k8s-secrets-injection/templates/_helpers.tpl
+++ b/charts/akeyless-k8s-secrets-injection/templates/_helpers.tpl
@@ -42,10 +42,17 @@ Create the name of the service account to use
 {{- end -}}
 {{- end -}}
 
-{{- define "gcp_artifacts_registry" -}}
-    {{- if .Values.image.gcp_artifact_registry.enabled }}
-        {{- printf "%s/" (.Values.image.gcp_artifact_registry.repository | trimSuffix "/") }}
+{{- define "docker_repository_server" -}}
+    {{- if .Values.image.dockerhub_cache.enabled }}
+        {{- printf "%s/%s" (.Values.image.dockerhub_cache.repository | trimSuffix "/") (.Values.image.server | trimPrefix "akeyless/")}}
     {{- else -}}
-        {{- print ""}}
+        {{ .Values.image.server }}
+    {{- end -}}
+{{- end -}}
+{{- define "docker_repository_agent" -}}
+    {{- if .Values.image.dockerhub_cache.enabled }}
+        {{- printf "%s/%s" (.Values.image.dockerhub_cache.repository | trimSuffix "/") (.Values.image.agent | trimPrefix "akeyless/")}}
+    {{- else -}}
+        {{ .Values.image.agent }}
     {{- end -}}
 {{- end -}}

--- a/charts/akeyless-k8s-secrets-injection/templates/_helpers.tpl
+++ b/charts/akeyless-k8s-secrets-injection/templates/_helpers.tpl
@@ -43,8 +43,8 @@ Create the name of the service account to use
 {{- end -}}
 
 {{- define "gcp_artifacts_registry" -}}
-    {{- if .Values.image.gcp_registry }}
-        {{- printf "%s/" (.Values.image.gcp_registry | trimSuffix "/") }}
+    {{- if .Values.image.gcp_artifact_registry.enabled }}
+        {{- printf "%s/" (.Values.image.gcp_artifact_registry.repository | trimSuffix "/") }}
     {{- else -}}
         {{- print ""}}
     {{- end -}}

--- a/charts/akeyless-k8s-secrets-injection/templates/_helpers.tpl
+++ b/charts/akeyless-k8s-secrets-injection/templates/_helpers.tpl
@@ -42,17 +42,10 @@ Create the name of the service account to use
 {{- end -}}
 {{- end -}}
 
-{{- define "docker_repository_server" -}}
-    {{- if .Values.image.dockerhub_cache.enabled }}
-        {{- printf "%s/%s" (.Values.image.dockerhub_cache.repository | trimSuffix "/") (.Values.image.server | trimPrefix "akeyless/")}}
+{{- define "docker_repository" -}}
+    {{- if .dockerhub_cache.enabled }}
+        {{- printf "%s/%s" (.dockerhub_cache.repository | trimSuffix "/") (.image | trimPrefix "akeyless/")}}
     {{- else -}}
-        {{ .Values.image.server }}
-    {{- end -}}
-{{- end -}}
-{{- define "docker_repository_agent" -}}
-    {{- if .Values.image.dockerhub_cache.enabled }}
-        {{- printf "%s/%s" (.Values.image.dockerhub_cache.repository | trimSuffix "/") (.Values.image.agent | trimPrefix "akeyless/")}}
-    {{- else -}}
-        {{ .Values.image.agent }}
+        {{ .image }}
     {{- end -}}
 {{- end -}}

--- a/charts/akeyless-k8s-secrets-injection/templates/_helpers.tpl
+++ b/charts/akeyless-k8s-secrets-injection/templates/_helpers.tpl
@@ -41,3 +41,11 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{- define "gcp_artifacts_registry" -}}
+    {{- if .Values.image.gcp_registry }}
+        {{- printf "%s/" (.Values.image.gcp_registry | trimSuffix "/") }}
+    {{- else -}}
+        {{- print ""}}
+    {{- end -}}
+{{- end -}}

--- a/charts/akeyless-k8s-secrets-injection/templates/webhook-deployment.yaml
+++ b/charts/akeyless-k8s-secrets-injection/templates/webhook-deployment.yaml
@@ -37,7 +37,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ template "gcp_artifacts_registry". }}{{ .Values.image.server }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           env:
           - name: TLS_CERT_FILE
             value: /var/serving-cert/servingCert
@@ -48,7 +48,7 @@ spec:
           - name: DEBUG
             value: {{ .Values.debug | quote }}
           - name: AKEYLESS_AGENT_IMAGE
-            value: "{{ .Values.image.agentImage }}:{{ .Values.image.tag | default .Chart.AppVersion  }}"
+            value: "{{ template "gcp_artifacts_registry". }}{{ .Values.image.agent }}:{{ .Values.image.tag | default .Chart.AppVersion  }}"
           {{- range $key, $value := .Values.env }}
           - name: {{ $key }}
             value: {{ $value }}

--- a/charts/akeyless-k8s-secrets-injection/templates/webhook-deployment.yaml
+++ b/charts/akeyless-k8s-secrets-injection/templates/webhook-deployment.yaml
@@ -37,7 +37,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ template "gcp_artifacts_registry". }}{{ .Values.image.server }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ template "docker_repository_server" . }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           env:
           - name: TLS_CERT_FILE
             value: /var/serving-cert/servingCert
@@ -48,7 +48,7 @@ spec:
           - name: DEBUG
             value: {{ .Values.debug | quote }}
           - name: AKEYLESS_AGENT_IMAGE
-            value: "{{ template "gcp_artifacts_registry". }}{{ .Values.image.agent }}:{{ .Values.image.tag | default .Chart.AppVersion  }}"
+            value: "{{ template "docker_repository_agent" . }}:{{ .Values.image.tag | default .Chart.AppVersion  }}"
           {{- range $key, $value := .Values.env }}
           - name: {{ $key }}
             value: {{ $value }}

--- a/charts/akeyless-k8s-secrets-injection/templates/webhook-deployment.yaml
+++ b/charts/akeyless-k8s-secrets-injection/templates/webhook-deployment.yaml
@@ -37,7 +37,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ template "docker_repository_server" . }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{- template "docker_repository" (merge .Values.image.server .Values.image) }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           env:
           - name: TLS_CERT_FILE
             value: /var/serving-cert/servingCert
@@ -48,7 +48,7 @@ spec:
           - name: DEBUG
             value: {{ .Values.debug | quote }}
           - name: AKEYLESS_AGENT_IMAGE
-            value: "{{ template "docker_repository_agent" . }}:{{ .Values.image.tag | default .Chart.AppVersion  }}"
+            value: "{{- template "docker_repository" (merge .Values.image.agent .Values.image) }}:{{ .Values.image.tag | default .Chart.AppVersion  }}"
           {{- range $key, $value := .Values.env }}
           - name: {{ $key }}
             value: {{ $value }}

--- a/charts/akeyless-k8s-secrets-injection/values.yaml
+++ b/charts/akeyless-k8s-secrets-injection/values.yaml
@@ -13,9 +13,9 @@ debug: false
 tlsCertsSecretName: vault-secrets-webhook-tls-certs
 
 image:
-  gcp_artifact_registry:
+  dockerhub_cache:
     enabled: false
-    repository: us-docker.pkg.dev/global-production-332815/dockerhub
+    repository: docker.akeyless.io
   server: akeyless/k8s-webhook-server
   agent: akeyless/k8s-secrets-sidecar
   pullPolicy: Always

--- a/charts/akeyless-k8s-secrets-injection/values.yaml
+++ b/charts/akeyless-k8s-secrets-injection/values.yaml
@@ -13,7 +13,9 @@ debug: false
 tlsCertsSecretName: vault-secrets-webhook-tls-certs
 
 image:
-  gcp_registry: us-docker.pkg.dev/global-production-332815/dockerhub
+  gcp_artifact_registry:
+    enabled: false
+    repository: us-docker.pkg.dev/global-production-332815/dockerhub
   server: akeyless/k8s-webhook-server
   agent: akeyless/k8s-secrets-sidecar
   pullPolicy: Always

--- a/charts/akeyless-k8s-secrets-injection/values.yaml
+++ b/charts/akeyless-k8s-secrets-injection/values.yaml
@@ -16,8 +16,10 @@ image:
   dockerhub_cache:
     enabled: false
     repository: docker.akeyless.io
-  server: akeyless/k8s-webhook-server
-  agent: akeyless/k8s-secrets-sidecar
+  server:
+    image: akeyless/k8s-webhook-server
+  agent:
+    image: akeyless/k8s-secrets-sidecar
   pullPolicy: Always
 
 serviceAccount:

--- a/charts/akeyless-k8s-secrets-injection/values.yaml
+++ b/charts/akeyless-k8s-secrets-injection/values.yaml
@@ -13,8 +13,9 @@ debug: false
 tlsCertsSecretName: vault-secrets-webhook-tls-certs
 
 image:
-  repository: akeyless/k8s-webhook-server
-  agentImage: akeyless/k8s-secrets-sidecar
+  gcp_registry: us-docker.pkg.dev/global-production-332815/dockerhub
+  server: akeyless/k8s-webhook-server
+  agent: akeyless/k8s-secrets-sidecar
   pullPolicy: Always
 
 serviceAccount:

--- a/charts/akeyless-zero-trust-web-access/Chart.yaml
+++ b/charts/akeyless-zero-trust-web-access/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.6.1
+version: 1.6.2
 appVersion: 0.14.5
 
 icon: https://akeylesslabs.github.io/helm-charts/assets/logo/akl.jpeg

--- a/charts/akeyless-zero-trust-web-access/Chart.yaml
+++ b/charts/akeyless-zero-trust-web-access/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 version: 1.6.1
-appVersion: 0.14.4
+appVersion: 0.14.5
 
 icon: https://akeylesslabs.github.io/helm-charts/assets/logo/akl.jpeg
 home: https://www.akeyless.io

--- a/charts/akeyless-zero-trust-web-access/Chart.yaml
+++ b/charts/akeyless-zero-trust-web-access/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.6.0
+version: 1.6.1
 appVersion: 0.14.4
 
 icon: https://akeylesslabs.github.io/helm-charts/assets/logo/akl.jpeg

--- a/charts/akeyless-zero-trust-web-access/templates/_helpers.tpl
+++ b/charts/akeyless-zero-trust-web-access/templates/_helpers.tpl
@@ -87,8 +87,8 @@ Checks kubernetes API version support for ingress BC
 {{- end -}}
 
 {{- define "gcp_artifacts_registry" -}}
-    {{- if .Values.image.gcp_registry }}
-        {{- printf "%s/" (.Values.image.gcp_registry | trimSuffix "/") }}
+    {{- if .Values.image.gcp_artifact_registry.enabled }}
+        {{- printf "%s/" (.Values.image.gcp_artifact_registry.repository | trimSuffix "/") }}
     {{- else -}}
         {{- print ""}}
     {{- end -}}

--- a/charts/akeyless-zero-trust-web-access/templates/_helpers.tpl
+++ b/charts/akeyless-zero-trust-web-access/templates/_helpers.tpl
@@ -86,10 +86,10 @@ Checks kubernetes API version support for ingress BC
   {{- end -}}
 {{- end -}}
 
-{{- define "gcp_artifacts_registry" -}}
-    {{- if .Values.image.gcp_artifact_registry.enabled }}
-        {{- printf "%s/" (.Values.image.gcp_artifact_registry.repository | trimSuffix "/") }}
+{{- define "docker_repository" -}}
+    {{- if .Values.image.dockerhub_cache.enabled }}
+        {{- printf "%s/%s" (.Values.image.dockerhub_cache.repository | trimSuffix "/") (.Values.webWorker.image.repository | trimPrefix "akeyless/")}}
     {{- else -}}
-        {{- print ""}}
+        {{ .Values.webWorker.image.repository }}
     {{- end -}}
 {{- end -}}

--- a/charts/akeyless-zero-trust-web-access/templates/_helpers.tpl
+++ b/charts/akeyless-zero-trust-web-access/templates/_helpers.tpl
@@ -85,3 +85,11 @@ Checks kubernetes API version support for ingress BC
     {{- print "extensions/v1beta1" -}}
   {{- end -}}
 {{- end -}}
+
+{{- define "gcp_artifacts_registry" -}}
+    {{- if .Values.image.gcp_registry }}
+        {{- printf "%s/" (.Values.image.gcp_registry | trimSuffix "/") }}
+    {{- else -}}
+        {{- print ""}}
+    {{- end -}}
+{{- end -}}

--- a/charts/akeyless-zero-trust-web-access/templates/web-worker-deployment.yaml
+++ b/charts/akeyless-zero-trust-web-access/templates/web-worker-deployment.yaml
@@ -70,7 +70,7 @@ spec:
       terminationGracePeriodSeconds: 3600
       containers:
         - name: {{ .Values.webWorker.containerName }}
-          image: "{{ .Values.webWorker.image.repository }}:{{ .Values.webWorker.image.tag  | default .Chart.AppVersion }}"
+          image: "{{template "gcp_artifacts_registry" .}}{{ .Values.webWorker.image.repository }}:{{ .Values.webWorker.image.tag  | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.webWorker.image.pullPolicy }}
           ports:
             - containerPort: 5800

--- a/charts/akeyless-zero-trust-web-access/templates/web-worker-deployment.yaml
+++ b/charts/akeyless-zero-trust-web-access/templates/web-worker-deployment.yaml
@@ -70,7 +70,7 @@ spec:
       terminationGracePeriodSeconds: 3600
       containers:
         - name: {{ .Values.webWorker.containerName }}
-          image: "{{template "gcp_artifacts_registry" .}}{{ .Values.webWorker.image.repository }}:{{ .Values.webWorker.image.tag  | default .Chart.AppVersion }}"
+          image: "{{template "docker_repository" .}}:{{ .Values.webWorker.image.tag  | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.webWorker.image.pullPolicy }}
           ports:
             - containerPort: 5800

--- a/charts/akeyless-zero-trust-web-access/values.yaml
+++ b/charts/akeyless-zero-trust-web-access/values.yaml
@@ -2,7 +2,9 @@
 
 image:
   dockerRepositoryCreds:
-  gcp_registry: us-docker.pkg.dev/global-production-332815/dockerhub
+  gcp_artifact_registry:
+    enabled: false
+    repository: us-docker.pkg.dev/global-production-332815/dockerhub
 
 # Linux system HTTP Proxy
 httpProxySettings:

--- a/charts/akeyless-zero-trust-web-access/values.yaml
+++ b/charts/akeyless-zero-trust-web-access/values.yaml
@@ -2,9 +2,9 @@
 
 image:
   dockerRepositoryCreds:
-  gcp_artifact_registry:
+  dockerhub_cache:
     enabled: false
-    repository: us-docker.pkg.dev/global-production-332815/dockerhub
+    repository: docker.akeyless.io
 
 # Linux system HTTP Proxy
 httpProxySettings:

--- a/charts/akeyless-zero-trust-web-access/values.yaml
+++ b/charts/akeyless-zero-trust-web-access/values.yaml
@@ -2,6 +2,7 @@
 
 image:
   dockerRepositoryCreds:
+  gcp_registry: us-docker.pkg.dev/global-production-332815/dockerhub
 
 # Linux system HTTP Proxy
 httpProxySettings:


### PR DESCRIPTION
Google added support for remote repositories so we can cache DockerHub (only the public repositories) 

This pr added support to pull the images using the google artifact registry, by setting `image.dockerhub_cache.enabled` to true on the values.yaml