### PR TITLE
Added support to pull from Google artifact registry

### DIFF
--- a/charts/akeyless-k8s-secrets-injection/Chart.yaml
+++ b/charts/akeyless-k8s-secrets-injection/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.2.28
+version: 1.2.29
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/akeyless-k8s-secrets-injection/values.yaml
+++ b/charts/akeyless-k8s-secrets-injection/values.yaml
@@ -15,6 +15,8 @@ tlsCertsSecretName: vault-secrets-webhook-tls-certs
 image:
   repository: docker.registry-2.akeyless.io/k8s-webhook-server
   agentImage: docker.registry-2.akeyless.io/k8s-secrets-sidecar
+
+##   Alternative mirror registry
 #  repository: akeyless/k8s-webhook-server
 #  agentImage: akeyless/k8s-secrets-sidecar
 

--- a/charts/akeyless-k8s-secrets-injection/values.yaml
+++ b/charts/akeyless-k8s-secrets-injection/values.yaml
@@ -13,8 +13,11 @@ debug: false
 tlsCertsSecretName: vault-secrets-webhook-tls-certs
 
 image:
-  repository: akeyless/k8s-webhook-server
-  agentImage: akeyless/k8s-secrets-sidecar
+  repository: docker.registry-2.akeyless.io/k8s-webhook-server
+  agentImage: docker.registry-2.akeyless.io/k8s-secrets-sidecar
+#  repository: akeyless/k8s-webhook-server
+#  agentImage: akeyless/k8s-secrets-sidecar
+
   pullPolicy: Always
 
 serviceAccount:

--- a/charts/akeyless-zero-trust-web-access/Chart.yaml
+++ b/charts/akeyless-zero-trust-web-access/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.6.2
+version: 1.6.3
 appVersion: 0.14.5
 
 icon: https://akeylesslabs.github.io/helm-charts/assets/logo/akl.jpeg

--- a/charts/akeyless-zero-trust-web-access/values.yaml
+++ b/charts/akeyless-zero-trust-web-access/values.yaml
@@ -159,6 +159,8 @@ webWorker:
       pullPolicy: IfNotPresent
   image:
     repository: docker.registry-2.akeyless.io/zero-trust-web-worker
+
+##   Alternative mirror registry
 #    repository: akeyless/zero-trust-web-worker
     pullPolicy: Always
 #    tag: latest

--- a/charts/akeyless-zero-trust-web-access/values.yaml
+++ b/charts/akeyless-zero-trust-web-access/values.yaml
@@ -158,7 +158,8 @@ webWorker:
       tag: 2021-04-04
       pullPolicy: IfNotPresent
   image:
-    repository: akeyless/zero-trust-web-worker
+    repository: docker.registry-2.akeyless.io/zero-trust-web-worker
+#    repository: akeyless/zero-trust-web-worker
     pullPolicy: Always
 #    tag: latest
 

--- a/docker-compose/akeyless-zero-trust-web-access/docker-compose.yml
+++ b/docker-compose/akeyless-zero-trust-web-access/docker-compose.yml
@@ -27,7 +27,8 @@ services:
         ipv4_address: 10.5.0.2
 
   worker:
-    image: "akeyless/zero-trust-web-worker"
+    image: "docker.registry-2.akeyless.io/zero-trust-web-worker"
+#    image: "akeyless/zero-trust-web-worker"
     security_opt:
       - seccomp=unconfined
     shm_size: '2gb'

--- a/docker-compose/akeyless-zero-trust-web-access/docker-compose.yml
+++ b/docker-compose/akeyless-zero-trust-web-access/docker-compose.yml
@@ -28,6 +28,7 @@ services:
 
   worker:
     image: "docker.registry-2.akeyless.io/zero-trust-web-worker"
+##   Alternative mirror registry
 #    image: "akeyless/zero-trust-web-worker"
     security_opt:
       - seccomp=unconfined


### PR DESCRIPTION
Google added support for remote repositories so we can cache DockerHub (only the public repositories)

This pr added support to pull the images using the google artifact registry