### PR TITLE
asm-5810 - Change the HPA order Memory before CPU

### DIFF
--- a/charts/akeyless-api-gateway/Chart.yaml
+++ b/charts/akeyless-api-gateway/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.23.4
+version: 1.23.5
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/akeyless-api-gateway/templates/horizontalPodAutoscaler.yaml
+++ b/charts/akeyless-api-gateway/templates/horizontalPodAutoscaler.yaml
@@ -16,14 +16,14 @@ spec:
   metrics:
     - type: Resource
       resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: {{ $.Values.HPA.cpuAvgUtil }}
-    - type: Resource
-      resource:
         name: memory
         target:
           type: Utilization
           averageUtilization: {{ $.Values.HPA.memAvgUtil }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ $.Values.HPA.cpuAvgUtil }}
   {{- end }}

--- a/charts/akeyless-secure-remote-access/Chart.yaml
+++ b/charts/akeyless-secure-remote-access/Chart.yaml
@@ -13,7 +13,7 @@ description: A Helm chart for Kubernetes akeyless-zero-trust-bastion and akeyles
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.13.22
+version: 0.13.23
 
 appVersion: v0.14.6_0.11.56
 # This is the version number of the application being deployed. This version number should be

--- a/charts/akeyless-secure-remote-access/templates/horizontalPodAutoscaler.yaml
+++ b/charts/akeyless-secure-remote-access/templates/horizontalPodAutoscaler.yaml
@@ -15,16 +15,16 @@ spec:
   metrics:
     - type: Resource
       resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: {{ $.Values.sshConfig.HPA.cpuAvgUtil }}
-    - type: Resource
-      resource:
         name: memory
         target:
           type: Utilization
           averageUtilization: {{ $.Values.sshConfig.HPA.memAvgUtil }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ $.Values.sshConfig.HPA.cpuAvgUtil }}
 {{- end }}
 {{- end }}
 ---

--- a/charts/akeyless-zero-trust-web-access/Chart.yaml
+++ b/charts/akeyless-zero-trust-web-access/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.6.1
+version: 1.6.2
 appVersion: 0.14.5
 
 icon: https://akeylesslabs.github.io/helm-charts/assets/logo/akl.jpeg

--- a/charts/akeyless-zero-trust-web-access/templates/horizontalPodAutoscaler.yaml
+++ b/charts/akeyless-zero-trust-web-access/templates/horizontalPodAutoscaler.yaml
@@ -14,16 +14,16 @@ spec:
   metrics:
     - type: Resource
       resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: {{ $.Values.HPA.dispatcher.cpuAvgUtil }}
-    - type: Resource
-      resource:
         name: memory
         target:
           type: Utilization
           averageUtilization: {{ $.Values.HPA.dispatcher.memAvgUtil }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ $.Values.HPA.dispatcher.cpuAvgUtil }}
 
 
 {{- if .Values.metrics.enabled }}


### PR DESCRIPTION
According to customer , k8s complains that the order on HPA is incorrect (Today CPU is first) and it requires Memory to be the first option