### PR TITLE
Support to modify MutatingWebhookConfiguration failurePolicy and namespace/object selectors

### DIFF
--- a/charts/akeyless-k8s-secrets-injection/Chart.yaml
+++ b/charts/akeyless-k8s-secrets-injection/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.2.28
+version: 1.2.29
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/akeyless-k8s-secrets-injection/README.md
+++ b/charts/akeyless-k8s-secrets-injection/README.md
@@ -48,19 +48,22 @@ helm delete RELEASE_NAME --namespace "${WEBHOOK_NS}"
 
 The following tables lists configurable parameters of the vault-secrets-webhook chart and their default values.
 
-|               Parameter             |                    Description                    |                  Default                 |
-| ----------------------------------- | ------------------------------------------------- | -----------------------------------------|
-|affinity                             |affinities to use                                  |{}                                        |
-|debug                                |debug logs for webhook                             |false                                     |
-|image.pullPolicy                     |image pull policy                                  |Always                                    |
-|image.repository                     |image repo that contains the admission server      |akeyless/k8s-webhook-server               |
-|image.tag                            |image tag                                          |latest                                    |
-|namespaceSelector                    |namespace selector to use, will limit webhook scope|{}                                        |
-|nodeSelector                         |node selector to use                               |{}                                        |
-|replicaCount                         |number of replicas                                 |1                                         |
-|resources                            |resources to request                               |{}                                        |
-|service.externalPort                 |webhook service external port                      |443                                       |
-|service.internalPort                 |webhook service external port                      |8443                                      |
-|service.name                         |webhook service name                               |secrets-webhook                           |
-|service.type                         |webhook service type                               |ClusterIP                                 |
-|tolerations                          |tolerations to add                                 |[]                                        |
+|               Parameter                                |                    Description                         |                  Default                 |
+| ------------------------------------------------------ | ------------------------------------------------------ | -----------------------------------------|
+|affinity                                                |affinities to use                                       |{}                                        |
+|debug                                                   |debug logs for webhook                                  |false                                     |
+|image.pullPolicy                                        |image pull policy                                       |Always                                    |
+|image.repository                                        |image repo that contains the admission server           |akeyless/k8s-webhook-server               |
+|image.tag                                               |image tag                                               |latest                                    |
+|namespaceSelector                                       |namespace selector to use, will limit webhook scope     |{}                                        |
+|nodeSelector                                            |node selector to use                                    |{}                                        |
+|replicaCount                                            |number of replicas                                      |1                                         |
+|resources                                               |resources to request                                    |{}                                        |
+|service.externalPort                                    |webhook service external port                           |443                                       |
+|service.internalPort                                    |webhook service external port                           |8443                                      |
+|service.name                                            |webhook service name                                    |secrets-webhook                           |
+|service.type                                            |webhook service type                                    |ClusterIP                                 |
+|tolerations                                             |tolerations to add                                      |[]                                        |
+|webhookConfiguration.failurePolicy                      |webhook failure policy                                  |Ignore                                    |
+|webhookConfiguration.namespaceSelector.matchExpressions |additional webhook namespace selector match expressions |{}                                        |
+|webhookConfiguration.objectSelector.matchExpressions    |additional webhook object selector match expressions    |{}                                        |

--- a/charts/akeyless-k8s-secrets-injection/templates/apiservice-webhook.yaml
+++ b/charts/akeyless-k8s-secrets-injection/templates/apiservice-webhook.yaml
@@ -38,18 +38,24 @@ items:
       - "*"
       resources:
       - pods
-    failurePolicy: Ignore
+    failurePolicy: {{ .Values.webhookConfiguration.failurePolicy | default "Ignore" }}
     namespaceSelector:
       matchExpressions:
       - key: name
         operator: NotIn
         values:
         - {{ .Release.Namespace }}
+      {{- with .Values.webhookConfiguration.namespaceSelector.matchExpressions }}
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
     objectSelector:
       matchExpressions:
       - key: release
         operator: NotIn
         values: 
         - {{ .Release.Name }}
+      {{- with .Values.webhookConfiguration.objectSelector.matchExpressions }}
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
     admissionReviewVersions: ["v1beta1"]
     sideEffects: None #Unknown

--- a/charts/akeyless-k8s-secrets-injection/values.yaml
+++ b/charts/akeyless-k8s-secrets-injection/values.yaml
@@ -81,3 +81,27 @@ affinity: |
           matchLabels:
             app: {{ template "vault-secrets-webhook.name" . }}
             release: {{ .Release.Name }}
+
+webhookConfiguration:
+  failurePolicy: "Ignore"
+  namespaceSelector:
+    matchExpressions: {}
+  objectSelector:
+    matchExpressions: {}
+
+# Example
+#  failurePolicy: "Fail"
+#
+#  namespaceSelector:
+#    matchExpressions:
+#      - key: <YOUR_NAMESPACE_LABEL_KEY>
+#        operator: In
+#        values:
+#        - <YOUR_NAMESPACE_LABEL_VALUES>
+#
+#  objectSelector:
+#    matchExpressions:
+#      - key: <YOUR_LABEL_KEY>
+#        operator: In
+#        values:
+#        - <YOUR_LABEL_VALUES>


### PR DESCRIPTION
Adds the ability to modify `failurePolicy` and to add namespace/object selector `matchExpressions` to the `MutatingWebhookConfiguration` object of the `k8s-secrets-injection` Helm chart; while respecting the default values.