### PR TITLE
Fix non-root cp error

### DIFF
--- a/charts/akeyless-api-gateway/Chart.yaml
+++ b/charts/akeyless-api-gateway/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.26.4
+version: 1.26.5
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/akeyless-api-gateway/templates/_helpers.tpl
+++ b/charts/akeyless-api-gateway/templates/_helpers.tpl
@@ -111,6 +111,14 @@ Generate chart secret name
 {{/*
 Check customer fragment
 */}}
+
+{{- define "akeyless-api-gw.root.config.path" -}}
+{{- if .Values.akeylessStrictMode }}
+     {{- printf "/home/akeyless" -}}
+{{- else }}
+     {{- printf "/root" -}}
+{{- end -}}
+{{- end -}}
 {{- define "akeyless-api-gw.customerFragmentExist" -}}
     {{- if .Values.customerFragments -}}
         {{- printf "true" -}}

--- a/charts/akeyless-api-gateway/templates/deployment.yaml
+++ b/charts/akeyless-api-gateway/templates/deployment.yaml
@@ -92,16 +92,16 @@ spec:
             - |
               set -ex
             {{- if eq (include "akeyless-api-gw.customerFragmentExist" .) "true"}}
-              [ "$(ls /customer_fragments)" ] && cp /customer_fragments/* /root/.akeyless
+              [ "$(ls /customer_fragments)" ] && cp /customer_fragments/* {{include "akeyless-api-gw.root.config.path" $}}/.akeyless
             {{- end }}
             {{- if eq (include "akeyless-api-gw.logandConfExist" .) "true"}}
-              cp /logand_conf/logand.conf /root/.akeyless/logand.conf
+              cp /logand_conf/logand.conf {{include "akeyless-api-gw.root.config.path" $}}/.akeyless/logand.conf
             {{- end }} 
             {{- if eq (include "akeyless-api-gw.tlsCertificateExist" .) "true"}}
-              cp /tls_conf/akeyless-api-cert.crt /root/.akeyless/akeyless-api-cert.crt
+              cp /tls_conf/akeyless-api-cert.crt {{include "akeyless-api-gw.root.config.path" $}}/.akeyless/akeyless-api-cert.crt
             {{- end }} 
             {{- if eq (include "akeyless-api-gw.tlsPrivateKeyExist" .) "true"}}
-              cp /tls_conf/akeyless-api-cert.key /root/.akeyless/akeyless-api-cert.key
+              cp /tls_conf/akeyless-api-cert.key {{include "akeyless-api-gw.root.config.path" $}}/.akeyless/akeyless-api-cert.key
             {{- end }} 
           volumeMounts:
           {{- if eq (include "akeyless-api-gw.customerFragmentExist" .) "true"}}
@@ -109,7 +109,7 @@ spec:
               mountPath: /customer_fragments
           {{- end }}
             - name: akeyless-config
-              mountPath: /root/.akeyless
+              mountPath: {{include "akeyless-api-gw.root.config.path" $}}/.akeyless
           {{- if eq (include "akeyless-api-gw.logandConfExist" .) "true"}}
             - name: logand-conf
               mountPath: /logand_conf
@@ -159,7 +159,7 @@ spec:
          {{- if or (eq (include "akeyless-api-gw.customerFragmentExist" .) "true") (eq (include "akeyless-api-gw.logandConfExist" .) "true") (eq (include "akeyless-api-gw.tlsCertificateExist" .) "true") ( .Values.metrics.enabled)}}
           volumeMounts:
             - name: akeyless-config
-              mountPath: /root/.akeyless
+              mountPath: {{include "akeyless-api-gw.root.config.path" $}}/.akeyless
           {{- if and (.Values.metrics.enabled) (eq (include "akeyless-api-gw.metricsSecretExist" .) "true") }}
             - name: otelcol-metrics-config
               mountPath: /akeyless/otel-config.yaml


### PR DESCRIPTION
The chart was using hardcoded `/root` we replaced it with a function to determine config root path to avoid access denied error