### PR TITLE
Add flexibility for TLS certificate and key file names

### DIFF
--- a/charts/akeyless-api-gateway/Chart.yaml
+++ b/charts/akeyless-api-gateway/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.28.7
+version: 1.28.8
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/akeyless-api-gateway/templates/_helpers.tpl
+++ b/charts/akeyless-api-gateway/templates/_helpers.tpl
@@ -63,6 +63,17 @@ Create the name of the service account to use
 {{- end -}}
 
 {{/*
+Set the default values of existing certificate files if not provided
+*/}}
+{{- define "akeyless-api-gw.certFileName" -}}
+{{- default "akeyless-api-cert.crt" .Values.TLSConf.overrideCertFileName -}}
+{{- end -}}
+
+{{- define "akeyless-api-gw.keyFileName" -}}
+{{- default "akeyless-api-cert.key" .Values.TLSConf.overrideKeyFileName -}}
+{{- end -}}
+
+{{/*
 Get the Ingress TLS secret.
 */}}
 {{- define "akeyless-api-gw.ingressSecretTLSName" -}}

--- a/charts/akeyless-api-gateway/templates/_helpers.tpl
+++ b/charts/akeyless-api-gateway/templates/_helpers.tpl
@@ -297,7 +297,7 @@ Check tlsCertificate
     {{- if .Values.TLSConf.tlsCertificate -}}
         {{- printf "true" -}}
     {{- else if and (lookup "v1" "Secret" .Release.Namespace (include "akeyless-api-gw.tlsSecretName" .)) .Values.TLSConf.tlsExistingSecretName -}}
-        {{- if hasKey (get (lookup "v1" "Secret" .Release.Namespace (include "akeyless-api-gw.tlsSecretName" . )) "data") "akeyless-api-cert.crt" -}}
+        {{- if hasKey (get (lookup "v1" "Secret" .Release.Namespace (include "akeyless-api-gw.tlsSecretName" . )) "data") ( default "akeyless-api-cert.crt" .Values.TLSConf.overrideCertFileName ) -}}
             {{- printf "true" -}}
         {{- else -}}
             {{- printf "false" -}}
@@ -314,7 +314,7 @@ Check tlsPrivateKey
     {{- if .Values.TLSConf.tlsPrivateKey -}}
         {{- printf "true" -}}
     {{- else if and (lookup "v1" "Secret" .Release.Namespace (include "akeyless-api-gw.tlsSecretName" .)) .Values.TLSConf.tlsExistingSecretName -}}
-        {{- if hasKey (get (lookup "v1" "Secret" .Release.Namespace (include "akeyless-api-gw.tlsSecretName" . )) "data") "akeyless-api-cert.key" -}}
+        {{- if hasKey (get (lookup "v1" "Secret" .Release.Namespace (include "akeyless-api-gw.tlsSecretName" . )) "data") ( default "akeyless-api-cert.key" .Values.TLSConf.overrideKeyFileName ) -}}
             {{- printf "true" -}}
         {{- else -}}
             {{- printf "false" -}}

--- a/charts/akeyless-api-gateway/templates/deployment.yaml
+++ b/charts/akeyless-api-gateway/templates/deployment.yaml
@@ -98,10 +98,10 @@ spec:
               cp /logand_conf/logand.conf {{include "akeyless-api-gw.root.config.path" $}}/.akeyless/logand.conf
             {{- end }} 
             {{- if eq (include "akeyless-api-gw.tlsCertificateExist" .) "true"}}
-              cp /tls_conf/{{ required "TLSConf.certFileName is required" .Values.TLSConf.certFileName }} {{include "akeyless-api-gw.root.config.path" $}}/.akeyless/akeyless-api-cert.crt
+              cp /tls_conf/{{ include "akeyless-api-gw.certFileName" . }} {{include "akeyless-api-gw.root.config.path" $}}/.akeyless/akeyless-api-cert.crt
             {{- end }} 
             {{- if eq (include "akeyless-api-gw.tlsPrivateKeyExist" .) "true"}}
-              cp /tls_conf/{{ required "TLSConf.keyFileName is required" .Values.TLSConf.keyFileName }} {{include "akeyless-api-gw.root.config.path" $}}/.akeyless/akeyless-api-cert.key
+              cp /tls_conf/{{ include "akeyless-api-gw.keyFileName" . }} {{include "akeyless-api-gw.root.config.path" $}}/.akeyless/akeyless-api-cert.key
             {{- end }} 
           volumeMounts:
           {{- if eq (include "akeyless-api-gw.customerFragmentExist" .) "true"}}

--- a/charts/akeyless-api-gateway/templates/deployment.yaml
+++ b/charts/akeyless-api-gateway/templates/deployment.yaml
@@ -98,10 +98,10 @@ spec:
               cp /logand_conf/logand.conf {{include "akeyless-api-gw.root.config.path" $}}/.akeyless/logand.conf
             {{- end }} 
             {{- if eq (include "akeyless-api-gw.tlsCertificateExist" .) "true"}}
-              cp /tls_conf/akeyless-api-cert.crt {{include "akeyless-api-gw.root.config.path" $}}/.akeyless/akeyless-api-cert.crt
+              cp /tls_conf/{{ required "TLSConf.certFileName is required" .Values.TLSConf.certFileName }} {{include "akeyless-api-gw.root.config.path" $}}/.akeyless/akeyless-api-cert.crt
             {{- end }} 
             {{- if eq (include "akeyless-api-gw.tlsPrivateKeyExist" .) "true"}}
-              cp /tls_conf/akeyless-api-cert.key {{include "akeyless-api-gw.root.config.path" $}}/.akeyless/akeyless-api-cert.key
+              cp /tls_conf/{{ required "TLSConf.keyFileName is required" .Values.TLSConf.keyFileName }} {{include "akeyless-api-gw.root.config.path" $}}/.akeyless/akeyless-api-cert.key
             {{- end }} 
           volumeMounts:
           {{- if eq (include "akeyless-api-gw.customerFragmentExist" .) "true"}}

--- a/charts/akeyless-api-gateway/values.yaml
+++ b/charts/akeyless-api-gateway/values.yaml
@@ -297,10 +297,10 @@ TLSConf:
   # Specifies an existing secret for tls-certificate:
   tlsExistingSecretName: 
   # Alter this property of you need to use a different input file name for the certificate, like from an existing secret
-  # Default value is 'akeyless-api-cert.crt' or change to your override file name and this proptery is required
+  # Default value is 'akeyless-api-cert.crt' or change to your override file name (this proptery is required)
   certFileName: 'akeyless-api-cert.crt'
   # Alter this property of you need to use a different input file name for the key, like from an existing secret
-  # Default value should be 'akeyless-api-cert.key' or change to your override file name and this proptery is required
+  # Default value should be 'akeyless-api-cert.key' or change to your override file name (this proptery is required)
   keyFileName: 'akeyless-api-cert.key'
   # 
   # tlsCertificate: |-

--- a/charts/akeyless-api-gateway/values.yaml
+++ b/charts/akeyless-api-gateway/values.yaml
@@ -296,7 +296,7 @@ TLSConf:
   minimumTlsVersion:
   # Specifies an existing secret for tls-certificate:
   tlsExistingSecretName: 
-  # Alter this property of you need to use a different input file name for the key, like from an existing secret
+  # Alter this property of you need to use a different input file name for the certificate, like from an existing secret
   # Default value is 'akeyless-api-cert.crt' or your override file name and is required
   certFileName: 'akeyless-api-cert.crt'
   # Alter this property of you need to use a different input file name for the key, like from an existing secret

--- a/charts/akeyless-api-gateway/values.yaml
+++ b/charts/akeyless-api-gateway/values.yaml
@@ -297,10 +297,10 @@ TLSConf:
   # Specifies an existing secret for tls-certificate:
   tlsExistingSecretName: 
   # Alter this property of you need to use a different input file name for the certificate, like from an existing secret
-  # Default value is 'akeyless-api-cert.crt' or your override file name and is required
+  # Default value is 'akeyless-api-cert.crt' or change to your override file name and this proptery is required
   certFileName: 'akeyless-api-cert.crt'
   # Alter this property of you need to use a different input file name for the key, like from an existing secret
-  # Default value should be 'akeyless-api-cert.key' or your override file name and is required
+  # Default value should be 'akeyless-api-cert.key' or change to your override file name and this proptery is required
   keyFileName: 'akeyless-api-cert.key'
   # 
   # tlsCertificate: |-

--- a/charts/akeyless-api-gateway/values.yaml
+++ b/charts/akeyless-api-gateway/values.yaml
@@ -294,10 +294,12 @@ TLSConf:
   enableSniProxy: false
   # minimumTlsVersion can be one of the following <TLSv1/TLSv1.1/TLSv1.2/TLSv1.3> 
   minimumTlsVersion:
-  # Specifies an existing secret for tls-certificate must include:
-  # - akeyless-api-cert.crt (base64)
-  # - akeyless-api-cert.key (base64)
+  # Specifies an existing secret for tls-certificate:
   tlsExistingSecretName: 
+  # Alter this property of you need to use a different input file name for the key, like from an existing secret
+  certFileName: 'akeyless-api-cert.crt'
+  # Alter this property of you need to use a different input file name for the key, like from an existing secret
+  keyFileName: 'akeyless-api-cert.key'
   # 
   # tlsCertificate: |-
   #   -----BEGIN CERTIFICATE-----

--- a/charts/akeyless-api-gateway/values.yaml
+++ b/charts/akeyless-api-gateway/values.yaml
@@ -296,12 +296,12 @@ TLSConf:
   minimumTlsVersion:
   # Specifies an existing secret for tls-certificate:
   tlsExistingSecretName: 
-  # Alter this property of you need to use a different input file name for the certificate, like from an existing secret
-  # Default value is 'akeyless-api-cert.crt' or change to your override file name (this proptery is required)
-  certFileName: 'akeyless-api-cert.crt'
-  # Alter this property of you need to use a different input file name for the key, like from an existing secret
-  # Default value should be 'akeyless-api-cert.key' or change to your override file name (this proptery is required)
-  keyFileName: 'akeyless-api-cert.key'
+  # Alter this property of you need to use a different INPUT file name for the certificate, like from an existing secret
+  # Default value is 'akeyless-api-cert.crt' or change to your override file name
+  overrideCertFileName:
+  # Alter this property of you need to use a different INPUT file name for the key, like from an existing secret
+  # Default value is 'akeyless-api-cert.key' or change to your override file name
+  overrideKeyFileName:
   # 
   # tlsCertificate: |-
   #   -----BEGIN CERTIFICATE-----

--- a/charts/akeyless-api-gateway/values.yaml
+++ b/charts/akeyless-api-gateway/values.yaml
@@ -297,8 +297,10 @@ TLSConf:
   # Specifies an existing secret for tls-certificate:
   tlsExistingSecretName: 
   # Alter this property of you need to use a different input file name for the key, like from an existing secret
+  # Default value is 'akeyless-api-cert.crt' or your override file name and is required
   certFileName: 'akeyless-api-cert.crt'
   # Alter this property of you need to use a different input file name for the key, like from an existing secret
+  # Default value should be 'akeyless-api-cert.key' or your override file name and is required
   keyFileName: 'akeyless-api-cert.key'
   # 
   # tlsCertificate: |-


### PR DESCRIPTION
This PR aims to provide more flexibility to the users of the akeyless-api-gateway Helm chart by allowing them to specify the names of the TLS certificate and key files.

Details:

Previously, the names of the certificate and key files were hardcoded as akeyless-api-cert.crt and akeyless-api-cert.key respectively. This became a problem when users wanted to use certificates generated by cert-manager, which uses the names tls.crt and tls.key for the certificate and key files respectively.

To solve this problem, we introduced two new properties in the values.yaml file.

.Values.TLSConf.certFileName
.Values.TLSConf. keyFileName

The required function is used to ensure that the deployment won't proceed unless these values are provided. If either TLSConf.certFileName or TLSConf.keyFileName are not provided, the Helm deployment will fail with an error message. This change ensures that the chart remains robust while providing additional flexibility to the users.

This change is backward compatible. If no file names are provided, the chart will default to using akeyless-api-cert.crt and akeyless-api-cert.key, maintaining the previous behavior.

This change will greatly improve the usability of the chart with automated certificate managers like cert-manager and make the chart more flexible for various user setups.