### PR TITLE
support non root user docker image

### DIFF
--- a/charts/akeyless-api-gateway/Chart.yaml
+++ b/charts/akeyless-api-gateway/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.29.0
+version: 1.29.1
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/akeyless-api-gateway/templates/_helpers.tpl
+++ b/charts/akeyless-api-gateway/templates/_helpers.tpl
@@ -113,7 +113,7 @@ Check customer fragment
 */}}
 
 {{- define "akeyless-api-gw.root.config.path" -}}
-{{- if .Values.akeylessStrictMode }}
+{{- if or (.Values.akeylessStrictMode) (hasSuffix "-akeyless" .Values.image.tag)   }}
      {{- printf "/home/akeyless" -}}
 {{- else }}
      {{- printf "/root" -}}


### PR DESCRIPTION
if customer use non root user docker image (with suffix -akeyless) use `/home/akeyless` as root config path