### PR TITLE
Asm 9135 istio support ztwa

### DIFF
--- a/charts/akeyless-zero-trust-web-access/Chart.yaml
+++ b/charts/akeyless-zero-trust-web-access/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.4.1
+version: 2.4.2
 appVersion: 1.2.1
 
 icon: https://akeylesslabs.github.io/helm-charts/assets/logo/akl.jpeg

--- a/charts/akeyless-zero-trust-web-access/templates/validator.yaml
+++ b/charts/akeyless-zero-trust-web-access/templates/validator.yaml
@@ -8,6 +8,9 @@ metadata:
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
   annotations:
+  {{- if .Values.validator.annotations }}
+    {{- toYaml .Values.validator.annotations | nindent 4 }}
+  {{- end }}
     "helm.sh/hook": post-install
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:

--- a/charts/akeyless-zero-trust-web-access/values.yaml
+++ b/charts/akeyless-zero-trust-web-access/values.yaml
@@ -21,6 +21,11 @@ validator:
     repository: apteno/alpine-jq
     pullPolicy: IfNotPresent
     tag: 2021-04-04
+  annotations: {}
+  # Remove the {} and add any needed annotations regarding your pod sidecar implementation
+  # For Example when using istio sidecar to avoid issues with validator job completion please add the following annotation:
+  #  annotations:
+  #    sidecar.istio.io/inject: "false"
 
 
 dispatcher:


### PR DESCRIPTION
When using sidecar and for example istio sidecar. validator job pod will run along istio sidecar and prevent validator pod job completion, and will cause ztwa helm chart install to be stack.
To prevent this issue, there are needed annotations to be added to validator to prevent from side to run.