### PR TITLE
add validator enable flag

### DIFF
--- a/charts/akeyless-zero-trust-web-access/Chart.yaml
+++ b/charts/akeyless-zero-trust-web-access/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.4.3
+version: 2.4.4
 appVersion: 1.2.2
 
 icon: https://akeylesslabs.github.io/helm-charts/assets/logo/akl.jpeg

--- a/charts/akeyless-zero-trust-web-access/templates/validator.yaml
+++ b/charts/akeyless-zero-trust-web-access/templates/validator.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.validator.enabled }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -31,3 +32,4 @@ spec:
               name: {{ $.Release.Name }}-cm-web-policies
               key: policies.json           
   restartPolicy: Never
+{{- end }}

--- a/charts/akeyless-zero-trust-web-access/values.yaml
+++ b/charts/akeyless-zero-trust-web-access/values.yaml
@@ -17,6 +17,9 @@ deployment:
   labels: {}
 
 validator:
+  # Validator is enabled by default, and will run on helm chart installation.
+  # If Validator set to false, policies validation will still run on the web-worker deployment, with the validator as init-container.
+  enabled: true
   image:
     repository: apteno/alpine-jq
     pullPolicy: IfNotPresent


### PR DESCRIPTION
Add validator enable flag to give the user ability to disable validator pod job on chart installation.
If Validator set to false, policies validation will still run on the web-worker deployment, with the validator as init-container.