### PR TITLE
Update sra chart to use unified docker image both for ssh and web bastions

### DIFF
--- a/.github/scripts/latest_version_release.sh
+++ b/.github/scripts/latest_version_release.sh
@@ -35,9 +35,7 @@ sed -i "s/version:.*/version: ${new_chart_version}/g" Chart.yaml
 # edit app version
 if [[ "${chart_dir}" == "akeyless-secure-remote-access" ]]; then
   # edit app service version
-  if [[ "${service}" == "ssh-proxy" ]]; then
-    sra_inner_chart="sshVersion"
-  elif [[ "${service}" == "zero-trust-bastion" ]]; then
+  if [[ "${service}" == "zero-trust-bastion" ]]; then
     sra_inner_chart="ztbVersion"
   elif [[ "${service}" == "zt-portal" ]]; then
     sra_inner_chart="ztpVersion"
@@ -49,8 +47,7 @@ if [[ "${chart_dir}" == "akeyless-secure-remote-access" ]]; then
   # edit sra app version
   ztb_app_ver=$(grep 'ztbVersion' Chart.yaml | awk '{print $2}')
   ztp_app_ver=$(grep 'ztpVersion' Chart.yaml | awk '{print $2}')
-  ssh_app_ver=$(grep 'sshVersion' Chart.yaml | awk '{print $2}')
-  sed -i "s/appVersion.*/appVersion: ${ztb_app_ver}_${ssh_app_ver}_${ztp_app_ver}/g" Chart.yaml
+  sed -i "s/appVersion.*/appVersion: ${ztb_app_ver}_${ztp_app_ver}/g" Chart.yaml
 
 else
   sed -i "s/appVersion.*/appVersion: ${app_version}/g" Chart.yaml

--- a/.github/scripts/latest_version_release.sh
+++ b/.github/scripts/latest_version_release.sh
@@ -11,8 +11,6 @@ app_version=$(echo "$GITHUB_CONTEXT" | jq -r '.payload.app_version | select (.!=
 
 if [[ "${service}" == "gateway" ]]; then
   chart_dir="akeyless-api-gateway"
-elif [[ "${service}" == "ssh-proxy" ]]; then
-  chart_dir="akeyless-secure-remote-access"
 elif [[ "${service}" == "zero-trust-bastion" ]]; then
   chart_dir="akeyless-secure-remote-access"
 elif [[ "${service}" == "zt-portal" ]]; then

--- a/charts/akeyless-secure-remote-access/Chart.yaml
+++ b/charts/akeyless-secure-remote-access/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 
-version: 0.29.5
+version: 0.29.0
 
 
 appVersion: v1.0.0_0.16.1_1.4.2

--- a/charts/akeyless-secure-remote-access/Chart.yaml
+++ b/charts/akeyless-secure-remote-access/Chart.yaml
@@ -17,11 +17,10 @@ type: application
 version: 0.29.0
 
 
-appVersion: v2.0.0_v2.0.0_1.4.2
+appVersion: 2.0.0_1.4.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 annotations:
-  ztbVersion: v2.0.0
-  sshVersion: v2.0.0
+  ztbVersion: 2.0.0
   ztpVersion: 1.4.2

--- a/charts/akeyless-secure-remote-access/Chart.yaml
+++ b/charts/akeyless-secure-remote-access/Chart.yaml
@@ -22,6 +22,6 @@ appVersion: v1.0.0_0.16.1_1.4.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 annotations:
-  ztbVersion: v1.0.0
-  sshVersion: 0.16.1
+  ztbVersion: v2.0.0
+  sshVersion: v2.0.0
   ztpVersion: 1.4.2

--- a/charts/akeyless-secure-remote-access/Chart.yaml
+++ b/charts/akeyless-secure-remote-access/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 version: 0.29.0
 
 
-appVersion: v1.0.0_0.16.1_1.4.2
+appVersion: v2.0.0_v2.0.0_1.4.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/akeyless-secure-remote-access/Chart.yaml
+++ b/charts/akeyless-secure-remote-access/Chart.yaml
@@ -17,10 +17,10 @@ type: application
 version: 0.29.0
 
 
-appVersion: 2.0.0_1.4.2
+appVersion: 1.0.0_1.4.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 annotations:
-  ztbVersion: 2.0.0
+  ztbVersion: 1.0.0
   ztpVersion: 1.4.2

--- a/charts/akeyless-secure-remote-access/Chart.yaml
+++ b/charts/akeyless-secure-remote-access/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 
-version: 0.28.5
+version: 0.28.6
 
 
 appVersion: v1.0.0_0.16.1_1.4.2

--- a/charts/akeyless-secure-remote-access/Chart.yaml
+++ b/charts/akeyless-secure-remote-access/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 
-version: 0.28.6
+version: 0.29.5
 
 
 appVersion: v1.0.0_0.16.1_1.4.2

--- a/charts/akeyless-secure-remote-access/README.md
+++ b/charts/akeyless-secure-remote-access/README.md
@@ -11,7 +11,7 @@ with signed certificate authentication, together with session recording.
 
 ## Introduction
 
-This chart bootstraps a Akeyless Zero Trust Bastion deployment,  Akeyless SSH bastion statefulset and a Akeyless Zero Trust Portal deployment on Kubernetes
+This chart bootstraps a Akeyless Zero Trust Bastion deployment,  Akeyless SSH bastion statefulset and a Akeyless Zero Trust Portal deployment on Kubernetes 
 cluster using the Helm package manager.
 
 ## Preparation

--- a/charts/akeyless-secure-remote-access/README.md
+++ b/charts/akeyless-secure-remote-access/README.md
@@ -11,7 +11,7 @@ with signed certificate authentication, together with session recording.
 
 ## Introduction
 
-This chart bootstraps a Akeyless Zero Trust Bastion deployment,  Akeyless SSH bastion statefulset and a Akeyless Zero Trust Portal deployment on Kubernetes 
+This chart bootstraps a Akeyless Zero Trust Bastion deployment,  Akeyless SSH bastion statefulset and a Akeyless Zero Trust Portal deployment on Kubernetes
 cluster using the Helm package manager.
 
 ## Preparation
@@ -94,21 +94,20 @@ The following table lists the configurable parameters of the Zero Trust Bastion 
 
 ### Deployment parameters
 
-| Parameter                      | Description                                                                                    | Default                       |
-|--------------------------------|------------------------------------------------------------------------------------------------|-------------------------------|
-| `ztbConfig.enabled`            | Enable Zero Trust Bastion                                                                      | `true`                        |
-| `ztbConfig.image.repository`   | Zero Trust Bastion image name                                                                  | `akeyless/zero-trust-bastion` |
-| `ztbConfig.image.tag`          | Zero Trust Bastion image tag                                                                   | `latest`                      |
-| `ztbConfig.image.pullPolicy`   | Zero Trust Bastion image pull policy                                                           | `Always`                      |
-| `ztbConfig.updateStrategy`     | Updating statefulset strategy                                                                  | `ztbConfig.RollingUpdate`     |
-| `ztbConfig.containerName`      | Zero Trust Bastion container name                                                              | `zero-trust-bastion`          |
-| `ztbConfig.replicaCount`       | Number of Zero Trust Bastion nodes                                                             | `1`                           |
-| `ztbConfig.livenessProbe`      | Liveness probe configuration for Zero Trust Bastion                                            | Check `values.yaml` file      |
-| `ztbConfig.readinessProbe`     | Readiness probe configuration for Zero Trust Bastion                                           | Check `values.yaml` file      |
+| Parameter                      | Description                                                                                     | Default                       |
+|--------------------------------|-------------------------------------------------------------------------------------------------|-------------------------------|
+| `ztbConfig.enabled`            | Enable Zero Trust Bastion                                                                       | `true`                        |
+| `ztbConfig.image.repository`   | Zero Trust Bastion image name                                                                   | `akeyless/zero-trust-bastion` |
+| `ztbConfig.image.tag`          | Zero Trust Bastion image tag                                                                    | `latest`                      |
+| `ztbConfig.image.pullPolicy`   | Zero Trust Bastion image pull policy                                                            | `Always`                      |
+| `ztbConfig.updateStrategy`     | Updating statefulset strategy                                                                   | `ztbConfig.RollingUpdate`     |
+| `ztbConfig.containerName`      | Zero Trust Bastion container name                                                               | `zero-trust-bastion`          |
+| `ztbConfig.replicaCount`       | Number of Zero Trust Bastion nodes                                                              | `1`                           |
+| `ztbConfig.livenessProbe`      | Liveness probe configuration for Zero Trust Bastion                                             | Check `values.yaml` file      |
+| `ztbConfig.readinessProbe`     | Readiness probe configuration for Zero Trust Bastion                                            | Check `values.yaml` file      |
 | `ztbConfig.resources.limits`   | The resources limits for Zero Trust Bastion containers (If HPA is enabled this must be set)    | `{}`                          |
 | `ztbConfig.resources.requests` | The requested resources for Zero Trust Bastion containers (If HPA is enabled this must be set) | `{}`                          |
-| `ztbConfig.allowedBastionUrls` | List of URLs that will be considered valid for redirection from the Portal back to the bastion | `[]`                          |
-| `ztbConfig.bastionType`        | The bastion type to run. Should be 'web' to run only web bastion services.                     | `web`                         |
+| `ztbConfig.allowedBastionUrls` | List of URLs that will be considered valid for redirection from the Portal back to the bastion  | `[]`                          |
 
 ### Exposure parameters
 
@@ -163,10 +162,9 @@ The following table lists the configurable parameters of the SSH Bastion chart a
 | `sshConfig.replicaCount`       | Number of SSH-Bastion nodes                                                                    | `1`                      |
 | `sshConfig.livenessProbe`      | Liveness probe configuration for SSH Bastion                                                   | Check `values.yaml` file |                   
 | `sshConfig.readinessProbe`     | Readiness probe configuration for SSH Bastion                                                  | Check `values.yaml` file |         
-| `sshConfig.resources.limits`   | The resources limits for SSH Bastion containers  (If HPA is enabled this must be set)          | `{}`                     |
-| `sshConfig.resources.requests` | The requested resources for SSH-Bastion containers (If HPA is enabled this must be set)        | `{}`                     |
+| `sshConfig.resources.limits`   | The resources limits for SSH Bastion containers  (If HPA is enabled this must be set)         | `{}`                     |
+| `sshConfig.resources.requests` | The requested resources for SSH-Bastion containers (If HPA is enabled this must be set)       | `{}`                     |
 | `sshConfig.allowedBastionUrls` | List of URLs that will be considered valid for redirection from the Portal back to the bastion | `[]`                     |
-| `sshConfig.bastionType`        | The bastion type to run. Should be 'ssh-proxy' to run only ssh-proxy services.                 | `ssh-proxy`              |
 
 ### Exposure parameters
 

--- a/charts/akeyless-secure-remote-access/README.md
+++ b/charts/akeyless-secure-remote-access/README.md
@@ -94,20 +94,21 @@ The following table lists the configurable parameters of the Zero Trust Bastion 
 
 ### Deployment parameters
 
-| Parameter                      | Description                                                                                     | Default                       |
-|--------------------------------|-------------------------------------------------------------------------------------------------|-------------------------------|
-| `ztbConfig.enabled`            | Enable Zero Trust Bastion                                                                       | `true`                        |
-| `ztbConfig.image.repository`   | Zero Trust Bastion image name                                                                   | `akeyless/zero-trust-bastion` |
-| `ztbConfig.image.tag`          | Zero Trust Bastion image tag                                                                    | `latest`                      |
-| `ztbConfig.image.pullPolicy`   | Zero Trust Bastion image pull policy                                                            | `Always`                      |
-| `ztbConfig.updateStrategy`     | Updating statefulset strategy                                                                   | `ztbConfig.RollingUpdate`     |
-| `ztbConfig.containerName`      | Zero Trust Bastion container name                                                               | `zero-trust-bastion`          |
-| `ztbConfig.replicaCount`       | Number of Zero Trust Bastion nodes                                                              | `1`                           |
-| `ztbConfig.livenessProbe`      | Liveness probe configuration for Zero Trust Bastion                                             | Check `values.yaml` file      |
-| `ztbConfig.readinessProbe`     | Readiness probe configuration for Zero Trust Bastion                                            | Check `values.yaml` file      |
+| Parameter                      | Description                                                                                    | Default                       |
+|--------------------------------|------------------------------------------------------------------------------------------------|-------------------------------|
+| `ztbConfig.enabled`            | Enable Zero Trust Bastion                                                                      | `true`                        |
+| `ztbConfig.image.repository`   | Zero Trust Bastion image name                                                                  | `akeyless/zero-trust-bastion` |
+| `ztbConfig.image.tag`          | Zero Trust Bastion image tag                                                                   | `latest`                      |
+| `ztbConfig.image.pullPolicy`   | Zero Trust Bastion image pull policy                                                           | `Always`                      |
+| `ztbConfig.updateStrategy`     | Updating statefulset strategy                                                                  | `ztbConfig.RollingUpdate`     |
+| `ztbConfig.containerName`      | Zero Trust Bastion container name                                                              | `zero-trust-bastion`          |
+| `ztbConfig.replicaCount`       | Number of Zero Trust Bastion nodes                                                             | `1`                           |
+| `ztbConfig.livenessProbe`      | Liveness probe configuration for Zero Trust Bastion                                            | Check `values.yaml` file      |
+| `ztbConfig.readinessProbe`     | Readiness probe configuration for Zero Trust Bastion                                           | Check `values.yaml` file      |
 | `ztbConfig.resources.limits`   | The resources limits for Zero Trust Bastion containers (If HPA is enabled this must be set)    | `{}`                          |
 | `ztbConfig.resources.requests` | The requested resources for Zero Trust Bastion containers (If HPA is enabled this must be set) | `{}`                          |
-| `ztbConfig.allowedBastionUrls` | List of URLs that will be considered valid for redirection from the Portal back to the bastion  | `[]`                          |
+| `ztbConfig.allowedBastionUrls` | List of URLs that will be considered valid for redirection from the Portal back to the bastion | `[]`                          |
+| `ztbConfig.bastionType`        | The bastion type to run. Should be 'web' to run only web bastion services.                     | `web`                         |
 
 ### Exposure parameters
 
@@ -162,9 +163,10 @@ The following table lists the configurable parameters of the SSH Bastion chart a
 | `sshConfig.replicaCount`       | Number of SSH-Bastion nodes                                                                    | `1`                      |
 | `sshConfig.livenessProbe`      | Liveness probe configuration for SSH Bastion                                                   | Check `values.yaml` file |                   
 | `sshConfig.readinessProbe`     | Readiness probe configuration for SSH Bastion                                                  | Check `values.yaml` file |         
-| `sshConfig.resources.limits`   | The resources limits for SSH Bastion containers  (If HPA is enabled this must be set)         | `{}`                     |
-| `sshConfig.resources.requests` | The requested resources for SSH-Bastion containers (If HPA is enabled this must be set)       | `{}`                     |
+| `sshConfig.resources.limits`   | The resources limits for SSH Bastion containers  (If HPA is enabled this must be set)          | `{}`                     |
+| `sshConfig.resources.requests` | The requested resources for SSH-Bastion containers (If HPA is enabled this must be set)        | `{}`                     |
 | `sshConfig.allowedBastionUrls` | List of URLs that will be considered valid for redirection from the Portal back to the bastion | `[]`                     |
+| `sshConfig.bastionType`        | The bastion type to run. Should be 'ssh-proxy' to run only ssh-proxy services.                 | `ssh-proxy`              |
 
 ### Exposure parameters
 

--- a/charts/akeyless-secure-remote-access/templates/deployment.yaml
+++ b/charts/akeyless-secure-remote-access/templates/deployment.yaml
@@ -96,10 +96,8 @@ spec:
             - name: ALLOWED_BASTION_URLS
               value: {{ range $index, $element := .Values.ztbConfig.allowedBastionUrls -}}{{- if $index -}},{{- end -}}{{ $element }}{{ end }}
 {{- end }}
-{{- if .Values.ztbConfig.bastionType }}
             - name: BASTION_TYPE
-              value: {{ .Values.ztbConfig.bastionType }}
-{{- end }}
+              value: "web"
 {{- with .Values.privilegedAccess }}
   {{- if (eq (include "secret-exist" (dict "Root" $.Values.privilegedAccess.existingSecretNames "Name" "access")) "true") }}
             - name: PRIVILEGED_ACCESS_ID

--- a/charts/akeyless-secure-remote-access/templates/deployment.yaml
+++ b/charts/akeyless-secure-remote-access/templates/deployment.yaml
@@ -96,7 +96,10 @@ spec:
             - name: ALLOWED_BASTION_URLS
               value: {{ range $index, $element := .Values.ztbConfig.allowedBastionUrls -}}{{- if $index -}},{{- end -}}{{ $element }}{{ end }}
 {{- end }}
-
+{{- if .Values.ztbConfig.bastionType }}
+            - name: BASTION_TYPE
+              value: {{ .Values.ztbConfig.bastionType }}
+{{- end }}
 {{- with .Values.privilegedAccess }}
   {{- if (eq (include "secret-exist" (dict "Root" $.Values.privilegedAccess.existingSecretNames "Name" "access")) "true") }}
             - name: PRIVILEGED_ACCESS_ID

--- a/charts/akeyless-secure-remote-access/templates/statefulSet.yaml
+++ b/charts/akeyless-secure-remote-access/templates/statefulSet.yaml
@@ -122,7 +122,7 @@ spec:
         - name: akeyless-docker-hub
       containers:
         - name: {{ .Values.sshConfig.containerName }}
-          image: "{{ .Values.sshConfig.image.repository }}:{{ .Values.sshConfig.image.tag | default .Chart.Annotations.sshVersion }}"
+          image: "{{ .Values.sshConfig.image.repository }}:{{ .Values.sshConfig.image.tag | default .Chart.Annotations.ztbVersion }}"
           imagePullPolicy: {{ .Values.sshConfig.image.pullPolicy }}
           securityContext:
             privileged: true
@@ -135,7 +135,7 @@ spec:
             name: curl-proxy
           env:
           - name: VERSION
-            value: {{ .Chart.Annotations.sshVersion }}
+            value: {{ .Chart.Annotations.ztbVersion }}
 {{- if .Values.clusterName }}
           - name: CLUSTER_NAME
             value: {{ .Values.clusterName }}

--- a/charts/akeyless-secure-remote-access/templates/statefulSet.yaml
+++ b/charts/akeyless-secure-remote-access/templates/statefulSet.yaml
@@ -172,10 +172,8 @@ spec:
           - name: ALLOWED_BASTION_URLS
             value: {{ range $index, $element := .Values.sshConfig.allowedBastionUrls -}}{{- if $index -}},{{- end -}}{{ $element }}{{ end }}
 {{- end }}
-{{- if .Values.sshConfig.bastionType }}
           - name: BASTION_TYPE
-            value: {{ .Values.sshConfig.bastionType }}
-{{- end }}
+            value: "ssh-proxy"
 {{- if .Values.httpProxySettings.http_proxy }}
           - name: HTTP_PROXY
             value: {{ .Values.httpProxySettings.http_proxy }}

--- a/charts/akeyless-secure-remote-access/templates/statefulSet.yaml
+++ b/charts/akeyless-secure-remote-access/templates/statefulSet.yaml
@@ -172,6 +172,10 @@ spec:
           - name: ALLOWED_BASTION_URLS
             value: {{ range $index, $element := .Values.sshConfig.allowedBastionUrls -}}{{- if $index -}},{{- end -}}{{ $element }}{{ end }}
 {{- end }}
+{{- if .Values.sshConfig.bastionType }}
+          - name: BASTION_TYPE
+            value: {{ .Values.sshConfig.bastionType }}
+{{- end }}
 {{- if .Values.httpProxySettings.http_proxy }}
           - name: HTTP_PROXY
             value: {{ .Values.httpProxySettings.http_proxy }}

--- a/charts/akeyless-secure-remote-access/values.yaml
+++ b/charts/akeyless-secure-remote-access/values.yaml
@@ -258,10 +258,7 @@ ztpConfig:
     memAvgUtil: 50
 
   containerName: "zero-trust-portal"
-  env:
-    # This env variable instruct docker to start only web-bastion processes
-    - name: "BASTION"
-      value: "web"
+  env: []
 
   image:
     repository: akeyless/zero-trust-portal
@@ -385,7 +382,7 @@ sshConfig:
       pullPolicy: IfNotPresent
 
   image:
-    repository: akeyless/zero-trust-portal
+    repository: akeyless/zero-trust-bastion
     pullPolicy: Always
     # tag: latest
 

--- a/charts/akeyless-secure-remote-access/values.yaml
+++ b/charts/akeyless-secure-remote-access/values.yaml
@@ -99,7 +99,10 @@ ztbConfig:
     # tag: latest
     
   containerName: "zero-trust-bastion"
-  env: []
+  env:
+    # This env variable instruct docker to start only web-bastion processes
+    - name: "BASTION"
+      value: "web"
 
   service:
     # Remove the {} and add any needed annotations regarding your LoadBalancer implementation
@@ -255,7 +258,10 @@ ztpConfig:
     memAvgUtil: 50
 
   containerName: "zero-trust-portal"
-  env: []
+  env:
+    # This env variable instruct docker to start only web-bastion processes
+    - name: "BASTION"
+      value: "web"
 
   image:
     repository: akeyless/zero-trust-portal
@@ -367,7 +373,11 @@ sshConfig:
     fsGroup: 0
     runAsUser: 0
 
-  env: []
+  env:
+    # This env variable instruct docker to start only ssh-proxy-bastion processes
+    - name: "BASTION"
+      value: "ssh-proxy"
+
   initContainer:
     image:
       repository: busybox
@@ -375,7 +385,7 @@ sshConfig:
       pullPolicy: IfNotPresent
 
   image:
-    repository: akeyless/ssh-proxy
+    repository: akeyless/zero-trust-portal
     pullPolicy: Always
     # tag: latest
 

--- a/charts/akeyless-secure-remote-access/values.yaml
+++ b/charts/akeyless-secure-remote-access/values.yaml
@@ -95,7 +95,7 @@ ztbConfig:
 
   image:
     repository: akeyless/zero-trust-bastion
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
     # tag: latest
     
   containerName: "zero-trust-bastion"
@@ -376,7 +376,7 @@ sshConfig:
 
   image:
     repository: akeyless/zero-trust-bastion
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
     # tag: latest
 
   containerName: "ssh-bastion"

--- a/charts/akeyless-secure-remote-access/values.yaml
+++ b/charts/akeyless-secure-remote-access/values.yaml
@@ -99,10 +99,7 @@ ztbConfig:
     # tag: latest
     
   containerName: "zero-trust-bastion"
-  env:
-    # This env variable instruct docker to start only web-bastion processes
-    - name: "BASTION"
-      value: "web"
+  env: []
 
   service:
     # Remove the {} and add any needed annotations regarding your LoadBalancer implementation
@@ -231,6 +228,8 @@ ztbConfig:
         azureTenantId: ""
       # Specifies an existing secret to be used for bastion, management AWS/Azure credentials
       existingSecret: ""
+
+  bastionType: "web"
 
 ####################################################
 ## Default values for akeyless-zero-trust-portal ##
@@ -370,11 +369,7 @@ sshConfig:
     fsGroup: 0
     runAsUser: 0
 
-  env:
-    # This env variable instruct docker to start only ssh-proxy-bastion processes
-    - name: "BASTION"
-      value: "ssh-proxy"
-
+  env: []
   initContainer:
     image:
       repository: busybox
@@ -473,3 +468,5 @@ sshConfig:
   allowedBastionUrls: []
     #- "bastion.my.org:2222"
     #- "basion.other.org:2222"
+
+  bastionType: "ssh-proxy"

--- a/charts/akeyless-secure-remote-access/values.yaml
+++ b/charts/akeyless-secure-remote-access/values.yaml
@@ -229,8 +229,6 @@ ztbConfig:
       # Specifies an existing secret to be used for bastion, management AWS/Azure credentials
       existingSecret: ""
 
-  bastionType: "web"
-
 ####################################################
 ## Default values for akeyless-zero-trust-portal ##
 ####################################################
@@ -468,5 +466,3 @@ sshConfig:
   allowedBastionUrls: []
     #- "bastion.my.org:2222"
     #- "basion.other.org:2222"
-
-  bastionType: "ssh-proxy"


### PR DESCRIPTION
We should decide what to do with the applications version.
I guess we want to use the same version for both apps (`sshVersion`,`ztbVersion`)

In that case we need to update the annotations in Chat.yaml to use only one annotation, we will discuess it..
Currently it's:
```
annotations:
  ztbVersion: v1.0.0
  sshVersion: 0.16.1 // need also to be v1.0.0?
  ztpVersion: 1.4.2
```
And it being concatenated: `appVersion: v1.0.0_0.16.1_1.4.2`

This can be merged only after @omriezra finish the pipline and the updated image is pushed to `akeyless/zero-trust-bastion` as latest.