### PR TITLE
Feature/asm 11750 redis tls

### DIFF
--- a/charts/akeyless-api-gateway/Chart.yaml
+++ b/charts/akeyless-api-gateway/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.48.0
+version: 1.48.1
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/akeyless-api-gateway/templates/_helpers.tpl
+++ b/charts/akeyless-api-gateway/templates/_helpers.tpl
@@ -440,7 +440,11 @@ Check metrics configuration Secret
 {{- end -}}
 
 {{- define "cacheAddress" -}}
+{{- if eq (include "cacheEnableTls" .) "true" -}}
 {{- printf "%s.%s.svc.cluster.local" (include "cacheSvcName" .) .Release.Namespace }}
+{{- else -}}
+{{- printf "%s.%s" (include "cacheSvcName" .) .Release.Namespace }}
+{{- end -}}
 {{- end -}}
 
 {{- define "akeyless-api-gw.cacheSvcName" }}


### PR DESCRIPTION
before it was svcName.NS now it's svcName.NS.svc.cluster.local, that's because coredns automatically adds .svc.cluster.local
The issue with that is that a tls certificate cannot be on svcName.NS so we need to have the full dns path to create the certificate 
In order to resolve BC we revert back to svcName.NS for non tls redis use