### PR TITLE
Support new approach for storing gateway cache encryption key in k8s secrets

### DIFF
--- a/charts/akeyless-api-gateway/Chart.yaml
+++ b/charts/akeyless-api-gateway/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.50.0
+version: 1.50.1
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/akeyless-api-gateway/templates/_helpers.tpl
+++ b/charts/akeyless-api-gateway/templates/_helpers.tpl
@@ -122,10 +122,8 @@ Generate chart secret name
 {{- define "akeyless-api-gw.clusterCacheEncryptionKeyExist" -}}
     {{- if .Values.cachingConf.clusterCache.encryptionKeyExistingSecret -}}
         {{- printf "%s" .Values.cachingConf.clusterCache.encryptionKeyExistingSecret -}}
-    {{- else -}}
-        {{- if .Values.cachingConf.clusterCache.enabled }}
-            {{- printf "%s-cache-encryption-key" .Release.Name -}}
-        {{- end -}}
+    {{- else if .Values.cachingConf.clusterCache.enabled -}}
+        {{- printf "%s-cache-encryption-key" .Release.Name -}}
     {{- end -}}
 {{- end -}}
 

--- a/charts/akeyless-api-gateway/templates/_helpers.tpl
+++ b/charts/akeyless-api-gateway/templates/_helpers.tpl
@@ -120,9 +120,13 @@ Generate chart secret name
 {{- end -}}
 
 {{- define "akeyless-api-gw.clusterCacheEncryptionKeyExist" -}}
-        {{- if .Values.cachingConf.clusterCache.encryptionKeyExistingSecret -}}
-            {{- printf "%s" .Values.cachingConf.clusterCache.encryptionKeyExistingSecret -}}
+    {{- if .Values.cachingConf.clusterCache.encryptionKeyExistingSecret -}}
+        {{- printf "%s" .Values.cachingConf.clusterCache.encryptionKeyExistingSecret -}}
+    {{- else -}}
+        {{- if .Values.cachingConf.clusterCache.enabled }}
+            {{- printf "%s-cache-encryption-key" .Release.Name -}}
         {{- end -}}
+    {{- end -}}
 {{- end -}}
 
 {{/* Define REDIS_MAXMEMORY as 80% of the pod's memory limit */}}

--- a/charts/akeyless-api-gateway/templates/deployment.yaml
+++ b/charts/akeyless-api-gateway/templates/deployment.yaml
@@ -291,11 +291,12 @@ spec:
           {{- if .Values.cachingConf.clusterCache.enabled }}
             - name: USE_CLUSTER_CACHE
               value: "true"
-            - name: CACHE_ENCRYPTION_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "akeyless-api-gw.clusterCacheEncryptionKeyExist" . }}
-                  key: cluster-cache-encryption-key
+            - name: STORE_CACHE_ENCRYPTION_KEY_TO_K8S_SECRETS
+              value: {{ .Values.cachingConf.clusterCache.storeEncryptionKeyToK8sSecrets | quote }}
+            {{- if not (eq (include "akeyless-api-gw.clusterCacheEncryptionKeyExist" .) "") }}
+            - name: CACHE_ENCRYPTION_KEY_SECRET_NAME
+              value: {{ include "akeyless-api-gw.clusterCacheEncryptionKeyExist" . | quote }}
+            {{- end }}
           {{- end }}
           {{- if .Values.universalIdentity.uidRotationInterval }}
             - name: UID_ROTATE_INTERVAL

--- a/charts/akeyless-api-gateway/templates/deployment.yaml
+++ b/charts/akeyless-api-gateway/templates/deployment.yaml
@@ -292,7 +292,7 @@ spec:
             - name: USE_CLUSTER_CACHE
               value: "true"
             - name: STORE_CACHE_ENCRYPTION_KEY_TO_K8S_SECRETS
-              value: {{ .Values.cachingConf.clusterCache.storeEncryptionKeyToK8sSecrets | quote }}
+              value: {{ .Values.cachingConf.clusterCache.enableScaleOutOnDisconnectedMode | quote }}
             {{- if not (eq (include "akeyless-api-gw.clusterCacheEncryptionKeyExist" .) "") }}
             - name: CACHE_ENCRYPTION_KEY_SECRET_NAME
               value: {{ include "akeyless-api-gw.clusterCacheEncryptionKeyExist" . | quote }}

--- a/charts/akeyless-api-gateway/templates/rbac.yaml
+++ b/charts/akeyless-api-gateway/templates/rbac.yaml
@@ -1,0 +1,35 @@
+{{/* RBAC rule to access the secret if storeEncryptionKeyToK8sSecrets is true and clusterCacheEncryptionKeyExist is not empty */}}
+{{- if and (eq $.Values.cachingConf.clusterCache.storeEncryptionKeyToK8sSecrets true) (not (.Values.cachingConf.clusterCache.encryptionKeyExistingSecret)) }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "akeyless-api-gw.getServiceAccountName" $ }}-secret-access
+  namespace: {{ $.Release.Namespace | quote }}
+rules:
+  # Rule to allow creating any secret (Refer - https://github.com/kubernetes/kubernetes/issues/80295)
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create"]
+
+  # Rule to allow getting and updating a specific secret
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: [{{ include "akeyless-api-gw.clusterCacheEncryptionKeyExist" $ | quote }}]
+    verbs: ["get", "update"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "akeyless-api-gw.getServiceAccountName" $ }}-secret-access-binding
+  namespace: {{ $.Release.Namespace | quote }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "akeyless-api-gw.getServiceAccountName" $ }}
+    namespace: {{ $.Release.Namespace | quote }}
+roleRef:
+  kind: Role
+  name: {{ template "akeyless-api-gw.getServiceAccountName" $ }}-secret-access
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/akeyless-api-gateway/templates/rbac.yaml
+++ b/charts/akeyless-api-gateway/templates/rbac.yaml
@@ -1,5 +1,5 @@
-{{/* RBAC rule to access the secret if storeEncryptionKeyToK8sSecrets is true and clusterCacheEncryptionKeyExist is not empty */}}
-{{- if and (eq $.Values.cachingConf.clusterCache.storeEncryptionKeyToK8sSecrets true) (not (.Values.cachingConf.clusterCache.encryptionKeyExistingSecret)) }}
+{{/* RBAC rule to access the secret if enableScaleOutOnDisconnectedMode is true and clusterCacheEncryptionKeyExist is not empty */}}
+{{- if and (eq $.Values.cachingConf.clusterCache.enableScaleOutOnDisconnectedMode true) (not (.Values.cachingConf.clusterCache.encryptionKeyExistingSecret)) }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/charts/akeyless-api-gateway/templates/serviceAccount.yaml
+++ b/charts/akeyless-api-gateway/templates/serviceAccount.yaml
@@ -10,41 +10,5 @@ metadata:
   annotations:
     {{- toYaml .annotations | nindent 4 }}
   {{- end }}
-
-  {{/* RBAC rule to access the secret if storeEncryptionKeyToK8sSecrets is true and clusterCacheEncryptionKeyExist is not empty */}}
-  {{- if and (eq $.Values.cachingConf.clusterCache.storeEncryptionKeyToK8sSecrets true) (not (eq (include "akeyless-api-gw.clusterCacheEncryptionKeyExist" $) "")) }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: {{ template "akeyless-api-gw.getServiceAccountName" $ }}-secret-access
-  namespace: {{ $.Release.Namespace | quote }}
-rules:
-  # Rule to allow creating any secret (Refer - https://github.com/kubernetes/kubernetes/issues/80295)
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["create"]
-
-  # Rule to allow getting and updating a specific secret
-  - apiGroups: [""]
-    resources: ["secrets"]
-    resourceNames: [{{ include "akeyless-api-gw.clusterCacheEncryptionKeyExist" $ | quote }}]
-    verbs: ["get", "update"]
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: {{ template "akeyless-api-gw.getServiceAccountName" $ }}-secret-access-binding
-  namespace: {{ $.Release.Namespace | quote }}
-subjects:
-  - kind: ServiceAccount
-    name: {{ template "akeyless-api-gw.getServiceAccountName" $ }}
-    namespace: {{ $.Release.Namespace | quote }}
-roleRef:
-  kind: Role
-  name: {{ template "akeyless-api-gw.getServiceAccountName" $ }}-secret-access
-  apiGroup: rbac.authorization.k8s.io
-  {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/akeyless-api-gateway/templates/serviceAccount.yaml
+++ b/charts/akeyless-api-gateway/templates/serviceAccount.yaml
@@ -1,5 +1,6 @@
 {{ with .Values.deployment.service_account }}
 {{- if (.create) }}
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -8,6 +9,42 @@ metadata:
   {{- if .annotations }}
   annotations:
     {{- toYaml .annotations | nindent 4 }}
-  {{- end -}}
-{{- end -}}
-{{- end -}}
+  {{- end }}
+
+  {{/* RBAC rule to access the secret if storeEncryptionKeyToK8sSecrets is true and clusterCacheEncryptionKeyExist is not empty */}}
+  {{- if and (eq $.Values.cachingConf.clusterCache.storeEncryptionKeyToK8sSecrets true) (not (eq (include "akeyless-api-gw.clusterCacheEncryptionKeyExist" $) "")) }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "akeyless-api-gw.getServiceAccountName" $ }}-secret-access
+  namespace: {{ $.Release.Namespace | quote }}
+rules:
+  # Rule to allow creating any secret (Refer - https://github.com/kubernetes/kubernetes/issues/80295)
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create"]
+
+  # Rule to allow getting and updating a specific secret
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: [{{ include "akeyless-api-gw.clusterCacheEncryptionKeyExist" $ | quote }}]
+    verbs: ["get", "update"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "akeyless-api-gw.getServiceAccountName" $ }}-secret-access-binding
+  namespace: {{ $.Release.Namespace | quote }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "akeyless-api-gw.getServiceAccountName" $ }}
+    namespace: {{ $.Release.Namespace | quote }}
+roleRef:
+  kind: Role
+  name: {{ template "akeyless-api-gw.getServiceAccountName" $ }}-secret-access
+  apiGroup: rbac.authorization.k8s.io
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/akeyless-api-gateway/templates/serviceAccount.yaml
+++ b/charts/akeyless-api-gateway/templates/serviceAccount.yaml
@@ -1,6 +1,5 @@
 {{ with .Values.deployment.service_account }}
 {{- if (.create) }}
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -9,6 +8,6 @@ metadata:
   {{- if .annotations }}
   annotations:
     {{- toYaml .annotations | nindent 4 }}
-  {{- end }}
-{{- end }}
-{{- end }}
+  {{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/akeyless-api-gateway/values.yaml
+++ b/charts/akeyless-api-gateway/values.yaml
@@ -406,7 +406,7 @@ cachingConf:
 
     # Set to true in order to store the cache encryption key in Kubernetes secrets for Scaling Up without network
     # connectivity (recommended for production)
-    storeEncryptionKeyToK8sSecrets: false
+    enableScaleOutOnDisconnectedMode: false
 
   proActiveCaching:
     enabled: false

--- a/charts/akeyless-api-gateway/values.yaml
+++ b/charts/akeyless-api-gateway/values.yaml
@@ -399,9 +399,14 @@ cachingConf:
 
   clusterCache:
     enabled: false
-    # In case clusterCache is enabled, you must specify an existing secret for the cluster cache configuration, must include:
-    # - cluster-cache-encryption-key
-    encryptionKeyExistingSecret: ""
+    # If clusterCache is enabled, a secret name can be specified in Kubernetes secrets. This allows the gateway
+    # to manage the secret content and store the cache encryption key. This is useful for Auto Scaling without network connectivity.
+    # If the service account not created by the chart, ensure the provided service account has permissions to create and update this secret.
+    encryptionKeyExistingSecret:
+
+    # Set to true in order to store the cache encryption key in Kubernetes secrets for Auto Scaling without network
+    # connectivity (recommended for production)
+    storeEncryptionKeyToK8sSecrets: false
 
   proActiveCaching:
     enabled: false

--- a/charts/akeyless-api-gateway/values.yaml
+++ b/charts/akeyless-api-gateway/values.yaml
@@ -400,11 +400,11 @@ cachingConf:
   clusterCache:
     enabled: false
     # If clusterCache is enabled, a secret name can be specified in Kubernetes secrets. This allows the gateway
-    # to manage the secret content and store the cache encryption key. This is useful for Auto Scaling without network connectivity.
+    # to manage the secret content and store the cache encryption key. This is useful for Scaling Up without network connectivity.
     # If the service account not created by the chart, ensure the provided service account has permissions to create and update this secret.
     encryptionKeyExistingSecret:
 
-    # Set to true in order to store the cache encryption key in Kubernetes secrets for Auto Scaling without network
+    # Set to true in order to store the cache encryption key in Kubernetes secrets for Scaling Up without network
     # connectivity (recommended for production)
     storeEncryptionKeyToK8sSecrets: false
 

--- a/charts/akeyless-api-gateway/values.yaml
+++ b/charts/akeyless-api-gateway/values.yaml
@@ -399,9 +399,9 @@ cachingConf:
 
   clusterCache:
     enabled: false
-    # If clusterCache is enabled, a secret name can be specified in Kubernetes secrets. This allows the gateway
-    # to manage the secret content and store the cache encryption key. This is useful for Scaling Up without network connectivity.
-    # If the service account not created by the chart, ensure the provided service account has permissions to create and update this secret.
+    # If clusterCache is enabled, the encryptionKeyExistingSecret parameter has a value (i.e., if you specify an existing secret for the encryption key), 
+    # Akeyless will use this specified encryption key and store it securely within the Akeyless Gateway.
+    # If the encryptionKeyExistingSecret parameter is empty or not specified, Akeyless will automatically generate a new encryption key for the cache.
     encryptionKeyExistingSecret:
 
   proActiveCaching:

--- a/charts/akeyless-api-gateway/values.yaml
+++ b/charts/akeyless-api-gateway/values.yaml
@@ -404,10 +404,6 @@ cachingConf:
     # If the service account not created by the chart, ensure the provided service account has permissions to create and update this secret.
     encryptionKeyExistingSecret:
 
-    # Set to true in order to store the cache encryption key in Kubernetes secrets for Scaling Up without network
-    # connectivity (recommended for production)
-    enableScaleOutOnDisconnectedMode: false
-
   proActiveCaching:
     enabled: false
 


### PR DESCRIPTION
## Description

Task: [ASM-12592 - Redis Enc Key Management In SaaS Gator](https://akeyless.atlassian.net/browse/ASM-12592)

## Changes:
- New field: `storeEncryptionKeyToK8sSecrets` - When set to `true`, the cache encryption key is stored in K8s secrets, supporting Auto Scaling scenarios without network connectivity.

- Enhancements to field `encryptionKeyExistingSecret`:
  - Still specifies the K8s secret name to be used for managing the cache encryption key.
  - If empty, the chart will generate name based on the deployment name
  - **The Gateway will use and manage this secret’s content**, will create/update the k8s secret with the cache enc key, useful for Scaling Up without network connectivity.
- When chart creating the **Service Account**, we also take care to create a **Role** and **Role Binding** to the created Service Account with appropriate **K8s secret permissions** (get, create, update) on this specific secret name, allowing the gateway to manage the cache encryption key securely in Kubernetes.
