### PR TITLE
ASM-13599 update broken links and add example annotations

### DIFF
--- a/charts/akeyless-api-gateway/values.yaml
+++ b/charts/akeyless-api-gateway/values.yaml
@@ -58,8 +58,20 @@ deployment:
   annotations: { }
   labels: { }
 
-  ## AWS ref: https://docs.akeyless.io/docs/deploy-the-api-gateway-on-kubernetes#aws-iam
-  ## GCP ref: https://docs.akeyless.io/docs/deploy-the-api-gateway-on-kubernetes#gcp-gce
+  # The service account to be used with the gateway pods created by deployment
+  # It can be configured to define how the gateway interacts with cloud provider service accounts.
+  
+  # - For GCP see https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity
+  #   ```yaml
+  #  annotations:
+  #      iam.gke.io/gcp-service-account: my-service-account@my-project.iam.gserviceaccount.com
+  #   ```
+
+  # - AWS ref: https://docs.aws.amazon.com/eks/latest/userguide/associate-service-account-role.html
+  #   ```yaml
+  #  annotations:
+  #    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/MyIAMRole
+  #   ```
   service_account:
     create: false
     serviceAccountName:


### PR DESCRIPTION
Update Akeyless Gateway Helm Chart comments that included broken links. Links were replaced with ones relevant for GCP and AWS along with annotation code sample.