### PR TITLE
[ASM-13755] Fix allowedAccessPermissions Type in Gateway Charts

### DIFF
--- a/charts/akeyless-api-gateway/Chart.yaml
+++ b/charts/akeyless-api-gateway/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.52.2
+version: 1.52.3
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/akeyless-api-gateway/Chart.yaml
+++ b/charts/akeyless-api-gateway/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.52.0
+version: 1.52.1
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/akeyless-api-gateway/Chart.yaml
+++ b/charts/akeyless-api-gateway/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.52.1
+version: 1.52.2
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/akeyless-api-gateway/values.schema.json
+++ b/charts/akeyless-api-gateway/values.schema.json
@@ -36,7 +36,7 @@
       }
     },
     "akeylessUserAuth": {
-      "description": "Container Image",
+      "description": "Akeyless authentication configuration",
       "properties": {
         "blockedAccessIds": {
           "oneOf": [
@@ -48,6 +48,24 @@
           ],
           "uniqueItems": true,
           "default": null
+        },
+        "allowedAccessPermissions": {
+          "type": "array",
+          "description": "List of allowed access permissions",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": { "type": "string" },
+              "access_id": { "type": "string" },
+              "sub_claims": { "type": "object" },
+              "case_sensitive": { "type": "boolean" },
+              "permissions": {
+                "type": "array",
+                "items": { "type": "string" }
+              }
+            },
+            "required": ["name", "access_id"]
+          }
         }
       },
       "type": "object"

--- a/charts/akeyless-api-gateway/values.yaml
+++ b/charts/akeyless-api-gateway/values.yaml
@@ -58,20 +58,8 @@ deployment:
   annotations: { }
   labels: { }
 
-  # The service account to be used with the gateway pods created by deployment
-  # It can be configured to define how the gateway interacts with cloud provider service accounts.
-  
-  # - For GCP see https://docs.akeyless.io/docs/gateway-k8s#gcp-gce
-  #   ```yaml
-  #  annotations:
-  #      iam.gke.io/gcp-service-account: my-service-account@my-project.iam.gserviceaccount.com
-  #   ```
-
-  # - AWS ref: https://docs.akeyless.io/docs/gateway-k8s#aws-iam
-  #   ```yaml
-  #  annotations:
-  #    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/MyIAMRole
-  #   ```
+  ## AWS ref: https://docs.akeyless.io/docs/deploy-the-api-gateway-on-kubernetes#aws-iam
+  ## GCP ref: https://docs.akeyless.io/docs/deploy-the-api-gateway-on-kubernetes#gcp-gce
   service_account:
     create: false
     serviceAccountName:

--- a/charts/akeyless-api-gateway/values.yaml
+++ b/charts/akeyless-api-gateway/values.yaml
@@ -58,8 +58,20 @@ deployment:
   annotations: { }
   labels: { }
 
-  ## AWS ref: https://docs.akeyless.io/docs/deploy-the-api-gateway-on-kubernetes#aws-iam
-  ## GCP ref: https://docs.akeyless.io/docs/deploy-the-api-gateway-on-kubernetes#gcp-gce
+  # The service account to be used with the gateway pods created by deployment
+  # It can be configured to define how the gateway interacts with cloud provider service accounts.
+  
+  # - For GCP see https://docs.akeyless.io/docs/gateway-k8s#gcp-gce
+  #   ```yaml
+  #  annotations:
+  #      iam.gke.io/gcp-service-account: my-service-account@my-project.iam.gserviceaccount.com
+  #   ```
+
+  # - AWS ref: https://docs.akeyless.io/docs/gateway-k8s#aws-iam
+  #   ```yaml
+  #  annotations:
+  #    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/MyIAMRole
+  #   ```
   service_account:
     create: false
     serviceAccountName:

--- a/charts/akeyless-api-gateway/values.yaml
+++ b/charts/akeyless-api-gateway/values.yaml
@@ -295,7 +295,7 @@ akeylessUserAuth:
   # Configure this list to add one or more allowed access to this GW, with the specified permissions and sub-claims.
   # Name must be unique.
   # Empty permissions will implicitly give the access admin permission.
-  allowedAccessPermissions: { }
+  allowedAccessPermissions: [ ]
   #    - name: access1
   #      access_id: p-1234
   #      sub_claims:

--- a/charts/akeyless-gateway/Chart.yaml
+++ b/charts/akeyless-gateway/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: akeyless-gateway
-version: 1.1.3
+version: 1.1.4
 description: A Helm chart for Kubernetes that deploys akeyless-gateway
 type: application
 keywords:

--- a/charts/akeyless-gateway/values.schema.json
+++ b/charts/akeyless-gateway/values.schema.json
@@ -1,0 +1,31 @@
+{
+    "$schema": "https://json-schema.org/draft-07/schema#",
+    "properties": {
+      "globalConfig": {
+        "type": "object",
+        "properties": {
+          "allowedAccessPermissions": {
+            "type": "array",
+            "description": "List of allowed access permissions",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": { "type": "string" },
+                "access_id": { "type": "string" },
+                "sub_claims": { "type": "object" },
+                "case_sensitive": { "type": "boolean" },
+                "permissions": {
+                  "type": "array",
+                  "items": { "type": "string" }
+                }
+              },
+              "required": ["name", "access_id"]
+            }
+          }
+        }
+      }
+    },
+    "title": "Values",
+    "type": "object"
+  }
+  

--- a/charts/akeyless-gateway/values.yaml
+++ b/charts/akeyless-gateway/values.yaml
@@ -19,7 +19,7 @@ globalConfig:
   ## Name must be unique. Empty permissions will implicitly give the admin permission.
   ## See docs for examples https://docs.akeyless.io/docs/gateway-chart#gateway-admins
   ##
-  allowedAccessPermissions: {}
+  allowedAccessPermissions: []
 
   ## Use a K8s existing secret for Gateway Allowed Access. Must include the following key: allowed-access-permissions
   ## https://docs.akeyless.io/docs/gateway-chart#access-permissions


### PR DESCRIPTION
## Description

When deploying a Gateway using either `akeyless-api-gateway` or `akeyless-gateway` and filling out the `akeylessUserAuth.allowedAccessPermissions` property in `values.yaml`, the comment above the property describes it as a list. However, the default value is an object:

```yaml
# Configure this list to add one or more allowed access to this GW, with the specified permissions and sub-claims.
# Name must be unique.
# Empty permissions will implicitly give the access admin permission.
allowedAccessPermissions: { }
```

When filling this section with a list of access permissions:

```yaml
allowedAccessPermissions:
    - name: kgal-access-permission-1
      access_id: p-1234
    - name: kgal-access-permission-2
      access_id: p-1235
```

And installing it, we get a warning:

```bash
helm upgrade akeyless-gw akeyless/akeyless-api-gateway -f values.yaml --install 

coalesce.go:286: warning: cannot overwrite table with non table for akeyless-api-gateway.akeylessUserAuth.allowedAccessPermissions (map[])
```

## Solution

To remove this warning, this PR introduces a few changes:

1. The values schema was changed to match the expected type and structure of the `allowedAccessPermissions` array in the API gateway chart.
2. The default value in the `values.yaml` was change to a list.
3. Add `values.schema.json` to unified gateway chart.


## Testing
To test this change, I used the same chart that produced the issue and used the changes in this ref to rerun the installation. As we can see in the output below, the warning is gone:

```bash
helm repo add akeyless-dev git+https://github.com/akeylesslabs/helm-charts@charts?ref=fix-allowedAccessPermissions-type-api-gw
"akeyless-dev" has been added to your repositories

helm upgrade akeyless-gw akeyless-dev/akeyless-api-gateway -f values.yaml --install

Release "akeyless-gw" has been upgraded. Happy Helming!
NAME: akeyless-gw
LAST DEPLOYED: Wed Jan 29 17:46:31 2025
NAMESPACE: default
STATUS: deployed
REVISION: 3
TEST SUITE: None
```