### PR TITLE
Fix context in persistent volume

### DIFF
--- a/charts/akeyless-gateway/Chart.yaml
+++ b/charts/akeyless-gateway/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: akeyless-gateway
-version: 1.4.0
+version: 1.4.1
 description: A Helm chart for Kubernetes that deploys akeyless-gateway
 type: application
 keywords:

--- a/charts/akeyless-gateway/templates/akeyless-secure-remote-access/pvc.yaml
+++ b/charts/akeyless-gateway/templates/akeyless-secure-remote-access/pvc.yaml
@@ -11,7 +11,7 @@ metadata:
   {{- toYaml .annotations | nindent 4 }}
 {{- end }}
   labels:
-  {{- include "akeyless-sra-web.labels" . | nindent 4 }}
+  {{- include "akeyless-sra-web.labels" $ | nindent 4 }}
 spec:
   accessModes:
     - ReadWriteMany


### PR DESCRIPTION
Using a range changes the context, to refer to the global context we must use $.

Otherwise this causes an error

```[ERROR] templates/: template: akeyless-gateway/templates/akeyless-secure-remote-access/pvc.yaml:14:6: executing "akeyless-gateway/templates/akeyless-secure-remote-access/pvc.yaml" at <include "akeyless-sra-web.labels" .>: error calling include: template: akeyless-gateway/templates/_helpers.tpl:347:18: executing "akeyless-sra-web.labels" at <include "akeyless-gateway.chart" .>: error calling include: template: akeyless-gateway/templates/_helpers.tpl:31:29: executing "akeyless-gateway.chart" at <.Chart.Name>: nil pointer evaluating interface {}.Name```