### PR TITLE
bug: Fix conditional check for metrics existing secret

### DIFF
--- a/charts/akeyless-gateway/templates/deployment.yaml
+++ b/charts/akeyless-gateway/templates/deployment.yaml
@@ -155,7 +155,7 @@ spec:
           {{- if (eq "true" (include "akeyless-gateway.clusterCache.enableTls" . )) }}
             {{ include "akeyless-gateway.clusterCache.tlsVolumeMounts" . | nindent 12 }}
           {{- end }}
-          {{- if and (.Values.globalConfig.metrics.enabled) (.Values.globalConfig.metrics.enabled) }}
+          {{- if and (.Values.globalConfig.metrics.enabled) (.Values.globalConfig.metrics.metricsExistingSecret) }}
             - name: otelcol-metrics-config
               mountPath: /akeyless/otel-config.yaml
               subPath: otel-config.yaml


### PR DESCRIPTION
This pull request updates the logic for mounting the metrics configuration in the `charts/akeyless-gateway/templates/deployment.yaml` file. The change ensures that the metrics configuration is only mounted when both metrics are enabled and an existing metrics secret is provided.

Metrics configuration logic update:

* Changed the conditional for mounting the `otelcol-metrics-config` volume to require both `.Values.globalConfig.metrics.enabled` and `.Values.globalConfig.metrics.metricsExistingSecret` to be true, instead of checking `.Values.globalConfig.metrics.enabled` twice.