### PR TITLE
feat(ztwa): ASM-17214 Add session recording configuration to ZTWA chart

### DIFF
--- a/charts/akeyless-zero-trust-web-access/templates/dispatcher-deployment.yaml
+++ b/charts/akeyless-zero-trust-web-access/templates/dispatcher-deployment.yaml
@@ -174,6 +174,34 @@ spec:
 {{- if .Values.dispatcher.env }}
           {{- toYaml .Values.dispatcher.env | nindent 12 }}
 {{- end }}
+{{- if .Values.dispatcher.config.recording.enabled }}
+            - name: ENABLE_RECORDING_UPLOAD
+              value: "true"
+            - name: RECORDING_COMPRESS
+              value: {{ .Values.dispatcher.config.recording.compress | quote }}
+            - name: RECORDING_SSE_TYPE
+              value: {{ .Values.dispatcher.config.recording.encryption.type | quote }}
+            - name: RECORDING_SSE_KMS_KEY_ID
+              value: {{ .Values.dispatcher.config.recording.encryption.kmsKeyId | quote }}
+{{- if .Values.dispatcher.config.recording.existingSecretName }}
+          envFrom:
+            - secretRef:
+                name: {{ .Values.dispatcher.config.recording.existingSecretName }}
+{{- else }}
+            - name: RECORDING_S3_BUCKET
+              value: {{ .Values.dispatcher.config.recording.s3.bucket | quote }}
+            - name: RECORDING_S3_PREFIX
+              value: {{ .Values.dispatcher.config.recording.s3.prefix | quote }}
+            - name: RECORDING_S3_REGION
+              value: {{ .Values.dispatcher.config.recording.s3.region | quote }}
+            - name: RECORDING_S3_ACCESS_KEY_ID
+              value: {{ .Values.dispatcher.config.recording.s3.accessKeyId | quote }}
+            - name: RECORDING_S3_ACCESS_KEY_SECRET
+              value: {{ .Values.dispatcher.config.recording.s3.accessKeySecret | quote }}
+            - name: RECORDING_S3_ENDPOINT
+              value: {{ .Values.dispatcher.config.recording.s3.endpoint | quote }}
+{{- end }}
+{{- end }}
           volumeMounts:
             - name: configmap-akeyless
               mountPath: /configmap_conf

--- a/charts/akeyless-zero-trust-web-access/templates/web-worker-deployment.yaml
+++ b/charts/akeyless-zero-trust-web-access/templates/web-worker-deployment.yaml
@@ -128,6 +128,12 @@ spec:
             - name: DISPLAY_HEIGHT
               value: {{ .Values.webWorker.config.displayHeight | quote }}
           {{- end }}
+{{- if .Values.dispatcher.config.recording.enabled }}
+            - name: ENABLE_RECORDING
+              value: "true"
+            - name: RECORDING_QUALITY
+              value: {{ .Values.dispatcher.config.recording.quality | quote }}
+{{- end }}
 {{- if .Values.webWorker.env }}
           {{- toYaml .Values.webWorker.env | nindent 12 }}
 {{- end }}

--- a/charts/akeyless-zero-trust-web-access/values.yaml
+++ b/charts/akeyless-zero-trust-web-access/values.yaml
@@ -193,6 +193,33 @@ dispatcher:
 #      target_splunk_token=""
 #      target_splunk_url=""
 
+    recording:
+      enabled: false
+      quality: "360p"  # 144p | 240p | 360p | 480p | 720p | 1080p (maps to CRF + framerate)
+      compress: false
+      encryption:
+        type: ""  # "" (none) | "sse-s3" | "sse-kms"
+        kmsKeyId: ""  # For sse-kms only
+
+      # S3 upload config (inline)
+      s3:
+        bucket: ""
+        prefix: "ztwa-recordings"
+        region: ""
+        # Leave empty to use IAM role / instance profile
+        accessKeyId: ""
+        accessKeySecret: ""
+        endpoint: ""  # For S3-compatible stores (NetApp, MinIO)
+
+      # Or reference existing K8s secret
+      existingSecretName: ""
+      # Secret should contain keys:
+      #   RECORDING_S3_BUCKET
+      #   RECORDING_S3_PREFIX (optional)
+      #   RECORDING_S3_REGION (optional)
+      #   RECORDING_S3_ACCESS_KEY_ID (optional)
+      #   RECORDING_S3_ACCESS_KEY_SECRET (optional)
+
 webWorker:
   replicaCount: 5
   initContainer:


### PR DESCRIPTION
- Added `dispatcher.config.recording` section to `values.yaml` to support S3 upload configuration, recording quality, compression, and SSE encryption.
- Updated `dispatcher-deployment.yaml` to inject the new recording environment variables into the dispatcher container.
- Updated `web-worker-deployment.yaml` to inject `ENABLE_RECORDING` and `RECORDING_QUALITY` environment variables into the worker container.