### PR TITLE
fix(ztwa): pod securityContext runAsNonRoot for restricted PSA/Kyverno

### DIFF
--- a/charts/akeyless-zero-trust-web-access/Chart.yaml
+++ b/charts/akeyless-zero-trust-web-access/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes that deploys akeyless-zero-trust-web-ac
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.0.4
+version: 3.0.5
 appVersion: 2.0.0-rc
 icon: https://akeylesslabs.github.io/helm-charts/assets/logo/akl.jpeg
 home: https://www.akeyless.io

--- a/charts/akeyless-zero-trust-web-access/README.md
+++ b/charts/akeyless-zero-trust-web-access/README.md
@@ -5,6 +5,9 @@
 This chart bootstraps a Akeyless-Zero-Trust-Web-Access deployment on a Kubernetes cluster using the Helm package manager.
 This chart has been tested to work with [NGINX Ingress](https://kubernetes.github.io/ingress-nginx/) and [cert-manager](https://cert-manager.io/).
 
+### Chart 3.0.5 — pod security hardening
+
+Version **3.0.5** adds **pod-level** `runAsNonRoot: true` on the dispatcher and web-worker Deployments (for restricted PSA / Kyverno policies that validate pod `securityContext`). The post-install **validator** Pod now runs as non-root with a writable `/tmp` so the default **`validator.enabled: true`** path can succeed under stricter admission.
 
 ## Preparation
 

--- a/charts/akeyless-zero-trust-web-access/templates/dispatcher-deployment.yaml
+++ b/charts/akeyless-zero-trust-web-access/templates/dispatcher-deployment.yaml
@@ -28,6 +28,7 @@ spec:
     spec:
       securityContext:
         fsGroup: 10000
+        runAsNonRoot: true
       volumes:
         - name: akeyless-config
           emptyDir: {}

--- a/charts/akeyless-zero-trust-web-access/templates/validator.yaml
+++ b/charts/akeyless-zero-trust-web-access/templates/validator.yaml
@@ -15,11 +15,19 @@ metadata:
     "helm.sh/hook": post-install
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
+  securityContext:
+    runAsNonRoot: true
+  volumes:
+    - name: validator-tmp
+      emptyDir: {}
   containers:
     - name: post-install-job
       image: "{{ .Values.validator.image.repository}}:{{ .Values.validator.image.tag }}"
       imagePullPolicy: {{ .Values.validator.image.pullPolicy }}
+      workingDir: /tmp
       securityContext:
+        runAsUser: 65534
+        runAsGroup: 65534
         runAsNonRoot: true
         allowPrivilegeEscalation: false
       command: ["/bin/sh"]
@@ -33,6 +41,9 @@ spec:
           valueFrom:
             configMapKeyRef:
               name: {{ $.Release.Name }}-cm-web-policies
-              key: policies.json           
+              key: policies.json
+      volumeMounts:
+        - name: validator-tmp
+          mountPath: /tmp
   restartPolicy: Never
 {{- end }}

--- a/charts/akeyless-zero-trust-web-access/templates/web-worker-deployment.yaml
+++ b/charts/akeyless-zero-trust-web-access/templates/web-worker-deployment.yaml
@@ -23,6 +23,7 @@ spec:
       securityContext:
         fsGroup: 10000
         supplementalGroups: [72]
+        runAsNonRoot: true
       volumes:
         - name: akeyless-conf
           emptyDir: {}


### PR DESCRIPTION
Bump akeyless-zero-trust-web-access chart to 3.0.5.

- Set pod-level runAsNonRoot on dispatcher and web-worker Deployments.
- Harden post-install validator Pod: pod securityContext, run as 65534, writable /tmp via emptyDir, allowPrivilegeEscalation false.

Document behavior in chart README.

Made-with: Cursor