### PR TITLE
Feat/ztwa recording helm env

### DIFF
--- a/charts/akeyless-zero-trust-web-access/Chart.yaml
+++ b/charts/akeyless-zero-trust-web-access/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes that deploys akeyless-zero-trust-web-ac
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.1.0
+version: 3.2.0
 appVersion: 2.0.0-rc
 icon: https://akeylesslabs.github.io/helm-charts/assets/logo/akl.jpeg
 home: https://www.akeyless.io

--- a/charts/akeyless-zero-trust-web-access/README.md
+++ b/charts/akeyless-zero-trust-web-access/README.md
@@ -29,6 +29,15 @@ For security reason, please limit the PersistentVolumes mount permissions to `06
    - file_mode=0650
 ```
 
+> **Important — single-node vs multi-node clusters**
+>
+> Session recording requires the dispatcher and web-worker pods to read/write the **same** `/etc/shared` directory because the worker writes `rec_*.mkv` and the dispatcher remuxes/uploads it.
+>
+> - **Single-node clusters** (k3s sandboxes, Minikube, kind) often default to a node-scoped provisioner such as `local-path`. This works only as long as every ZTWA pod schedules on the same node; deleting a pod with an in-progress recording also deletes the partial MKV (the directory belongs to that pod's local-path).
+> - **Multi-node production clusters** must use a real RWX storage class backed by NFS, AWS EFS, Azure Files, GCP Filestore, Longhorn, etc. Without RWX, dispatcher and worker pods scheduled on different nodes will not see each other's files and recordings will be silently lost.
+>
+> The chart does not enforce a specific provisioner — pick the one that matches your cluster's topology and pin it via `persistence.shareStorageVolume.storageClassName`.
+
 ### Session Recording (Optional)
 
 ZTWA can capture Firefox web sessions to video files (`.mp4`) and optionally upload them to S3-compatible storage.
@@ -138,6 +147,33 @@ webWorker:
 - **Worker Recycle**: Worker liveness probes terminate inactive sessions (default `webWorker.sessionCleanup.staleGraceSeconds: 30`). The recorder receives `SIGTERM` and flushes; whatever was captured up to that point is retained.
 - **Storage**: Ensure shared volume has sufficient capacity for concurrent sessions and upload backlog
 - **Retention**: Configure S3 lifecycle policies for long-term retention management
+
+#### Lifecycle Watchdog (Abort Detection and Runaway Cap)
+
+The worker enforces two guard rails so a single stuck session can never permanently occupy a worker pod:
+
+1. **Client connect-timeout** — when ZTWA assigns a session, the dispatcher creates `/tmp/occupied` on the worker and `session_recorder` starts capturing. If the browser tab is opened but never establishes a websocket on `:5800` (network blip, user closes the tab before the page loads), the worker tears the session down after `WORKER_CLIENT_CONNECT_TIMEOUT_SECONDS` (default **90 seconds**) so the liveness probe can recycle the pod.
+2. **Recording max-duration** — `session_recorder` caps a single recording at `SESSION_RECORDER_WATCHDOG_MAX_DURATION` (default **4 hours**). When exceeded, ffmpeg is signalled gracefully and the dispatcher uploads whatever was captured. Set to `0` to disable.
+
+Defaults are baked into the image; expose them only when you need to override:
+
+```yaml
+sessionRecording:
+  watchdog:
+    # How long the worker waits for the browser to fully connect after assignment.
+    # Empty string (default) = 90 seconds.
+    clientConnectTimeoutSeconds: ""
+
+    # How often the recorder watchdog wakes up to check the max-duration cap.
+    # Empty string (default) = 30s. Format: Go duration string ("10s", "1m", ...).
+    intervalSeconds: ""
+
+    # Hard upper bound on a single recording. Empty string (default) = 4h.
+    # Format: Go duration string ("4h", "8h", "0" to disable).
+    maxDurationSeconds: ""
+```
+
+Tune `maxDurationSeconds` higher (e.g. `8h`, `12h`) for environments with long-running interactive sessions such as 24/7 dashboards, and lower (e.g. `1h`) when sessions should be force-closed sooner.
 
 #### Credential Mechanisms (Priority Order)
 

--- a/charts/akeyless-zero-trust-web-access/README.md
+++ b/charts/akeyless-zero-trust-web-access/README.md
@@ -134,9 +134,8 @@ webWorker:
 #### Upload Behavior and Limitations
 
 - **Asynchronous Upload**: Recordings are uploaded 60-90+ seconds after session end (60s poll interval + 30s stability check)
-- **Partial Recordings**: Worker liveness probes terminate inactive sessions (default `staleGraceSeconds: 30`), which can truncate recordings mid-session. This is by design for resource cleanup. To prioritize complete recordings:
-  - Increase `webWorker.sessionCleanup.staleGraceSeconds` (trade-off: slower cleanup)
-  - Disable liveness probes (trade-off: manual cleanup required)
+- **Worker Capture Format**: Workers write Matroska (`rec_*.mkv`) to the shared volume. The dispatcher remuxes to standard `rec_*.mp4` with `ffmpeg` before S3 upload, so the customer-facing artifact in S3 stays `.mp4`. MKV-on-disk is truncation-resilient: if a worker is terminated mid-session (liveness recycle, eviction, manual restart) the partial bytes already written are still playable, and the dispatcher remuxes whatever it finds.
+- **Worker Recycle**: Worker liveness probes terminate inactive sessions (default `webWorker.sessionCleanup.staleGraceSeconds: 30`). The recorder receives `SIGTERM` and flushes; whatever was captured up to that point is retained.
 - **Storage**: Ensure shared volume has sufficient capacity for concurrent sessions and upload backlog
 - **Retention**: Configure S3 lifecycle policies for long-term retention management
 
@@ -153,13 +152,13 @@ The dispatcher upload service tries credentials in this order:
 #### Troubleshooting
 
 - **Permission Denied on State File**: Ensure `fsGroup: 10000` is set on dispatcher pod (chart default). State file lives at `/etc/shared/upload/recording_uploader_state.json` by default (group-writable).
-- **No Recordings Created**: Check `ENABLE_RECORDING=true` on worker pods (`kubectl logs <worker-pod>`). Verify shared volume is mounted at `/etc/shared`.
-- **Upload Failures**: Check dispatcher logs for S3 errors. Verify bucket/region/credentials. Test with `aws s3 ls s3://<bucket>` using the same credentials.
-- **Partial Recordings**: Expected behavior when worker restarts occur. Adjust `staleGraceSeconds` or review liveness probe configuration.
+- **No Recordings Created**: Check `ENABLE_RECORDING=true` on worker pods (`kubectl logs <worker-pod>`). Verify the `session_recorder` service started cleanly (it preflights `/etc/shared` and `/bin/ffmpeg` on boot and fails fast otherwise). Verify the shared volume is mounted at `/etc/shared`.
+- **Upload Failures**: Check dispatcher logs for S3 errors. Verify bucket/region/credentials. Test with `aws s3 ls s3://<bucket>` using the same credentials. The dispatcher also remuxes `.mkv` -> `.mp4` before upload; remux failures are logged and the source `.mkv` is retained for retry.
+- **Truncated Sessions**: When a worker is recycled mid-session, the recording captured up to `SIGTERM` is uploaded as a valid (shorter) `.mp4`. To extend in-progress sessions, raise `webWorker.sessionCleanup.staleGraceSeconds`.
 
 #### Backward Compatibility
 
-Existing deployments using `dispatcher.config.recording.*` and `webWorker.config.recording.*` continue to function identically. The unified `sessionRecording.*` section is **opt-in** and recommended for new deployments. See `BACKWARD_COMPAT_TEST.md` for migration guidance.
+Existing deployments using `dispatcher.config.recording.*` and `webWorker.config.recording.*` continue to function identically. The unified `sessionRecording.*` section is **opt-in** and recommended for new deployments.
 
 ### Prerequisites
 

--- a/charts/akeyless-zero-trust-web-access/README.md
+++ b/charts/akeyless-zero-trust-web-access/README.md
@@ -29,9 +29,137 @@ For security reason, please limit the PersistentVolumes mount permissions to `06
    - file_mode=0650
 ```
 
-### Session recording (optional)
+### Session Recording (Optional)
 
-Configure **`dispatcher.config.recording`** to set S3 upload options for the dispatcher (`ENABLE_RECORDING_UPLOAD`, `RECORDING_S3_*`, compression, SSE, and optional **`uploaderStatePath`** for `RECORDING_UPLOADER_STATE_PATH`). Configure **`webWorker.config.recording`** for capture settings (`ENABLE_RECORDING`, `RECORDING_QUALITY`). Both paths require **`persistence.shareStorageVolume`** so `/etc/shared` is mounted on dispatcher and web-worker pods. Prefer injecting secrets via **`dispatcher.env`** / **`webWorker.env`** with `valueFrom` instead of storing credentials in plain values.
+ZTWA can capture Firefox web sessions to video files (`.mp4`) and optionally upload them to S3-compatible storage.
+
+#### Prerequisites
+
+1. **Shared Volume**: Configure `persistence.shareStorageVolume` with a `ReadWriteMany` PersistentVolumeClaim (e.g., NFS, Azure Files, EFS) so `/etc/shared` is mounted on both dispatcher and web-worker pods.
+2. **Security Context**: The chart automatically sets `securityContext.fsGroup: 10000` on dispatcher and worker pods to allow the non-root `nobody` user (supplementary group `shared` GID 10000) to write recordings and state files. Omitting `fsGroup` commonly yields permission denied errors.
+3. **S3 Credentials** (for upload):
+   - **Recommended**: Use IAM roles (AWS IRSA, GKE Workload Identity) or inject secrets via `dispatcher.env` with `valueFrom.secretKeyRef`
+   - **Not Recommended**: Hardcoding `s3AccessKeyId` and `s3AccessKeySecret` in `values.yaml`
+
+#### Configuration (Recommended: Unified Model)
+
+Use the unified `sessionRecording` section for simplified configuration:
+
+```yaml
+sessionRecording:
+  # Enable video capture on web-worker pods
+  enabled: true
+  
+  # Recording quality: 144p|240p|360p|480p|720p|1080p (affects file size and CPU)
+  quality: "360p"
+  
+  # S3 upload configuration (dispatcher-side)
+  upload:
+    enabled: true
+    s3Bucket: "my-ztwa-recordings"
+    s3Region: "us-east-1"
+    # Optional: organize recordings in a prefix
+    s3Prefix: "recordings"
+    # Optional: custom S3-compatible endpoint (MinIO, Wasabi, etc.)
+    s3Endpoint: ""
+    # Optional: enable gzip compression before upload (reduces storage costs)
+    compress: true
+    # Server-side encryption
+    sse:
+      # type: "" (none), "sse-s3" (AES-256), or "sse-kms"
+      type: "sse-s3"
+      # kmsKeyId: optional KMS key ARN for sse-kms
+      kmsKeyId: ""
+
+persistence:
+  shareStorageVolume:
+    name: share-storage
+    storageClassName: "efs-sc"  # Example: EFS storage class
+    accessModes:
+      - ReadWriteMany
+    size: 10Gi
+```
+
+**Credentials**: Use IAM roles or inject via secrets:
+
+```yaml
+dispatcher:
+  env:
+    - name: RECORDING_S3_ACCESS_KEY_ID
+      valueFrom:
+        secretKeyRef:
+          name: s3-credentials
+          key: access-key-id
+    - name: RECORDING_S3_ACCESS_KEY_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: s3-credentials
+          key: secret-access-key
+```
+
+#### Advanced Configuration (Per-Service Overrides)
+
+For advanced use cases (e.g., different quality per worker pool, separate S3 buckets), use service-specific overrides. These take precedence over the unified `sessionRecording` section:
+
+```yaml
+# Unified config provides defaults
+sessionRecording:
+  enabled: true
+  quality: "360p"
+  upload:
+    enabled: true
+    s3Bucket: "default-bucket"
+
+# Override dispatcher upload settings (takes precedence)
+dispatcher:
+  config:
+    recording:
+      enabled: true
+      s3Bucket: "high-priority-bucket"
+      s3Region: "eu-west-1"
+      compress: true
+
+# Override worker capture settings (takes precedence)
+webWorker:
+  config:
+    recording:
+      enabled: true
+      quality: "720p"  # Higher quality for specific worker pool
+```
+
+**Precedence Rules**:
+- Dispatcher: `dispatcher.config.recording.*` > `sessionRecording.upload.*` > `dispatcher.env[]`
+- Worker: `webWorker.config.recording.*` > `sessionRecording.*` > `webWorker.env[]`
+
+#### Upload Behavior and Limitations
+
+- **Asynchronous Upload**: Recordings are uploaded 60-90+ seconds after session end (60s poll interval + 30s stability check)
+- **Partial Recordings**: Worker liveness probes terminate inactive sessions (default `staleGraceSeconds: 30`), which can truncate recordings mid-session. This is by design for resource cleanup. To prioritize complete recordings:
+  - Increase `webWorker.sessionCleanup.staleGraceSeconds` (trade-off: slower cleanup)
+  - Disable liveness probes (trade-off: manual cleanup required)
+- **Storage**: Ensure shared volume has sufficient capacity for concurrent sessions and upload backlog
+- **Retention**: Configure S3 lifecycle policies for long-term retention management
+
+#### Credential Mechanisms (Priority Order)
+
+The dispatcher upload service tries credentials in this order:
+
+1. **Explicit S3 keys**: `sessionRecording.upload.s3AccessKeyId` / `s3AccessKeySecret` (or `dispatcher.config.recording.*`)
+2. **AWS Default Credential Chain**: Environment variables, IAM instance profile, IRSA, shared credentials file
+3. **Log Forwarding Fallback**: Extracts bucket/region/credentials from `dispatcher.config.logForward` when `target_log_type=aws_s3` and S3 bucket is empty
+
+**Best Practice**: Use option #2 (IAM roles) for production deployments.
+
+#### Troubleshooting
+
+- **Permission Denied on State File**: Ensure `fsGroup: 10000` is set on dispatcher pod (chart default). State file lives at `/etc/shared/upload/recording_uploader_state.json` by default (group-writable).
+- **No Recordings Created**: Check `ENABLE_RECORDING=true` on worker pods (`kubectl logs <worker-pod>`). Verify shared volume is mounted at `/etc/shared`.
+- **Upload Failures**: Check dispatcher logs for S3 errors. Verify bucket/region/credentials. Test with `aws s3 ls s3://<bucket>` using the same credentials.
+- **Partial Recordings**: Expected behavior when worker restarts occur. Adjust `staleGraceSeconds` or review liveness probe configuration.
+
+#### Backward Compatibility
+
+Existing deployments using `dispatcher.config.recording.*` and `webWorker.config.recording.*` continue to function identically. The unified `sessionRecording.*` section is **opt-in** and recommended for new deployments. See `BACKWARD_COMPAT_TEST.md` for migration guidance.
 
 ### Prerequisites
 

--- a/charts/akeyless-zero-trust-web-access/README.md
+++ b/charts/akeyless-zero-trust-web-access/README.md
@@ -29,6 +29,10 @@ For security reason, please limit the PersistentVolumes mount permissions to `06
    - file_mode=0650
 ```
 
+### Session recording (optional)
+
+Configure **`dispatcher.config.recording`** to set S3 upload options for the dispatcher (`ENABLE_RECORDING_UPLOAD`, `RECORDING_S3_*`, compression, SSE, and optional **`uploaderStatePath`** for `RECORDING_UPLOADER_STATE_PATH`). Configure **`webWorker.config.recording`** for capture settings (`ENABLE_RECORDING`, `RECORDING_QUALITY`). Both paths require **`persistence.shareStorageVolume`** so `/etc/shared` is mounted on dispatcher and web-worker pods. Prefer injecting secrets via **`dispatcher.env`** / **`webWorker.env`** with `valueFrom` instead of storing credentials in plain values.
+
 ### Prerequisites
 
 #### Horizonal Auto-Scaling

--- a/charts/akeyless-zero-trust-web-access/README.md
+++ b/charts/akeyless-zero-trust-web-access/README.md
@@ -46,9 +46,9 @@ ZTWA can capture Firefox web sessions to video files (`.mp4`) and optionally upl
 
 1. **Shared Volume**: Configure `persistence.shareStorageVolume` with a `ReadWriteMany` PersistentVolumeClaim (e.g., NFS, Azure Files, EFS) so `/etc/shared` is mounted on both dispatcher and web-worker pods.
 2. **Security Context**: The chart automatically sets `securityContext.fsGroup: 10000` on dispatcher and worker pods to allow the non-root `nobody` user (supplementary group `shared` GID 10000) to write recordings and state files. Omitting `fsGroup` commonly yields permission denied errors.
-3. **S3 Credentials** (for upload):
-   - **Recommended**: Use IAM roles (AWS IRSA, GKE Workload Identity) or inject secrets via `dispatcher.env` with `valueFrom.secretKeyRef`
-   - **Not Recommended**: Hardcoding `s3AccessKeyId` and `s3AccessKeySecret` in `values.yaml`
+3. **S3 Credentials** (for upload): the chart never accepts plain credentials in `values.yaml`. Choose one of:
+   - **IAM roles** (AWS IRSA, GKE Workload Identity) — recommended for production. Leave `sessionRecording.upload.existingSecretNames.s3` empty so the dispatcher picks up the AWS default credential chain.
+   - **Kubernetes Secret** — create the Secret out-of-band and reference it via `sessionRecording.upload.existingSecretNames.s3`. See "Kubernetes Secret" below.
 
 #### Configuration (Recommended: Unified Model)
 
@@ -89,22 +89,25 @@ persistence:
     size: 10Gi
 ```
 
-**Credentials**: Use IAM roles or inject via secrets:
+**Credentials — Kubernetes Secret**: create the Secret out-of-band and reference it from `values.yaml`. The chart wires the dispatcher's `RECORDING_S3_ACCESS_KEY_ID` / `RECORDING_S3_ACCESS_KEY_SECRET` env vars to the Secret via `secretKeyRef`.
+
+```bash
+kubectl create secret generic ztwa-s3-credentials \
+  --from-literal=access-key-id=AKIA... \
+  --from-literal=secret-access-key=...
+```
 
 ```yaml
-dispatcher:
-  env:
-    - name: RECORDING_S3_ACCESS_KEY_ID
-      valueFrom:
-        secretKeyRef:
-          name: s3-credentials
-          key: access-key-id
-    - name: RECORDING_S3_ACCESS_KEY_SECRET
-      valueFrom:
-        secretKeyRef:
-          name: s3-credentials
-          key: secret-access-key
+sessionRecording:
+  upload:
+    existingSecretNames:
+      s3: ztwa-s3-credentials
+      # Override the keys inside the Secret if you used different field names:
+      # s3AccessKeyIdKey: access-key-id
+      # s3SecretAccessKeyKey: secret-access-key
 ```
+
+**Credentials — IAM roles (no Secret)**: leave `existingSecretNames.s3` unset. The dispatcher's `recording_uploader` falls through to the AWS default credential chain (IRSA, instance profile, or `AWS_*` env vars you may inject via `dispatcher.env`).
 
 #### Advanced Configuration (Per-Service Overrides)
 
@@ -179,11 +182,11 @@ Tune `maxDurationSeconds` higher (e.g. `8h`, `12h`) for environments with long-r
 
 The dispatcher upload service tries credentials in this order:
 
-1. **Explicit S3 keys**: `sessionRecording.upload.s3AccessKeyId` / `s3AccessKeySecret` (or `dispatcher.config.recording.*`)
-2. **AWS Default Credential Chain**: Environment variables, IAM instance profile, IRSA, shared credentials file
-3. **Log Forwarding Fallback**: Extracts bucket/region/credentials from `dispatcher.config.logForward` when `target_log_type=aws_s3` and S3 bucket is empty
+1. **Kubernetes Secret**: when `sessionRecording.upload.existingSecretNames.s3` is set, the chart wires the Secret's keys into `RECORDING_S3_ACCESS_KEY_ID` / `RECORDING_S3_ACCESS_KEY_SECRET` via `secretKeyRef`.
+2. **AWS Default Credential Chain**: Environment variables, IAM instance profile, IRSA, shared credentials file. Used when `existingSecretNames.s3` is empty.
+3. **Log Forwarding Fallback**: Extracts bucket/region/credentials from `dispatcher.config.logForward` when `target_log_type=aws_s3` and S3 bucket is empty.
 
-**Best Practice**: Use option #2 (IAM roles) for production deployments.
+**Best Practice**: Use option #2 (IAM roles) for production deployments. Option #1 is the right choice when IAM is unavailable (on-prem, MinIO, etc.).
 
 #### Troubleshooting
 

--- a/charts/akeyless-zero-trust-web-access/templates/dispatcher-deployment.yaml
+++ b/charts/akeyless-zero-trust-web-access/templates/dispatcher-deployment.yaml
@@ -182,6 +182,32 @@ spec:
             - name: no_proxy
               value: {{ .Values.httpProxySettings.no_proxy }}
 {{- end }}
+{{- with .Values.dispatcher.config.recording }}
+            - name: ENABLE_RECORDING_UPLOAD
+              value: {{ ternary "true" "false" .enabled }}
+            - name: RECORDING_S3_BUCKET
+              value: {{ .s3Bucket | quote }}
+            - name: RECORDING_S3_PREFIX
+              value: {{ .s3Prefix | quote }}
+            - name: RECORDING_S3_REGION
+              value: {{ .s3Region | quote }}
+            - name: RECORDING_S3_ACCESS_KEY_ID
+              value: {{ .s3AccessKeyId | quote }}
+            - name: RECORDING_S3_ACCESS_KEY_SECRET
+              value: {{ .s3AccessKeySecret | quote }}
+            - name: RECORDING_S3_ENDPOINT
+              value: {{ .s3Endpoint | quote }}
+            - name: RECORDING_COMPRESS
+              value: {{ ternary "true" "false" .compress }}
+            - name: RECORDING_SSE_TYPE
+              value: {{ .sseType | quote }}
+            - name: RECORDING_SSE_KMS_KEY_ID
+              value: {{ .sseKmsKeyId | quote }}
+            {{- if .uploaderStatePath }}
+            - name: RECORDING_UPLOADER_STATE_PATH
+              value: {{ .uploaderStatePath | quote }}
+            {{- end }}
+{{- end }}
 {{- if .Values.dispatcher.env }}
           {{- toYaml .Values.dispatcher.env | nindent 12 }}
 {{- end }}

--- a/charts/akeyless-zero-trust-web-access/templates/dispatcher-deployment.yaml
+++ b/charts/akeyless-zero-trust-web-access/templates/dispatcher-deployment.yaml
@@ -182,32 +182,73 @@ spec:
             - name: no_proxy
               value: {{ .Values.httpProxySettings.no_proxy }}
 {{- end }}
-{{- with .Values.dispatcher.config.recording }}
-            - name: ENABLE_RECORDING_UPLOAD
-              value: {{ ternary "true" "false" .enabled }}
-            - name: RECORDING_S3_BUCKET
-              value: {{ .s3Bucket | quote }}
-            - name: RECORDING_S3_PREFIX
-              value: {{ .s3Prefix | quote }}
-            - name: RECORDING_S3_REGION
-              value: {{ .s3Region | quote }}
-            - name: RECORDING_S3_ACCESS_KEY_ID
-              value: {{ .s3AccessKeyId | quote }}
-            - name: RECORDING_S3_ACCESS_KEY_SECRET
-              value: {{ .s3AccessKeySecret | quote }}
-            - name: RECORDING_S3_ENDPOINT
-              value: {{ .s3Endpoint | quote }}
-            - name: RECORDING_COMPRESS
-              value: {{ ternary "true" "false" .compress }}
-            - name: RECORDING_SSE_TYPE
-              value: {{ .sseType | quote }}
-            - name: RECORDING_SSE_KMS_KEY_ID
-              value: {{ .sseKmsKeyId | quote }}
-            {{- if .uploaderStatePath }}
-            - name: RECORDING_UPLOADER_STATE_PATH
-              value: {{ .uploaderStatePath | quote }}
-            {{- end }}
+{{- /* Recording env: precedence is dispatcher.config.recording (service override) > sessionRecording.upload (unified) */}}
+{{- $recEnabled := false }}
+{{- $recBucket := "" }}
+{{- $recPrefix := "" }}
+{{- $recRegion := "" }}
+{{- $recKeyId := "" }}
+{{- $recKeySecret := "" }}
+{{- $recEndpoint := "" }}
+{{- $recCompress := false }}
+{{- $recSSEType := "" }}
+{{- $recSSEKmsKey := "" }}
+{{- $recStatePath := "" }}
+{{- if .Values.dispatcher.config.recording }}
+  {{- /* Service-specific override takes precedence */}}
+  {{- $recEnabled = .Values.dispatcher.config.recording.enabled }}
+  {{- $recBucket = .Values.dispatcher.config.recording.s3Bucket }}
+  {{- $recPrefix = .Values.dispatcher.config.recording.s3Prefix }}
+  {{- $recRegion = .Values.dispatcher.config.recording.s3Region }}
+  {{- $recKeyId = .Values.dispatcher.config.recording.s3AccessKeyId }}
+  {{- $recKeySecret = .Values.dispatcher.config.recording.s3AccessKeySecret }}
+  {{- $recEndpoint = .Values.dispatcher.config.recording.s3Endpoint }}
+  {{- $recCompress = .Values.dispatcher.config.recording.compress }}
+  {{- $recSSEType = .Values.dispatcher.config.recording.sseType }}
+  {{- $recSSEKmsKey = .Values.dispatcher.config.recording.sseKmsKeyId }}
+  {{- $recStatePath = .Values.dispatcher.config.recording.uploaderStatePath }}
+{{- else if .Values.sessionRecording }}
+  {{- /* Fallback to unified configuration */}}
+  {{- if .Values.sessionRecording.upload }}
+    {{- $recEnabled = .Values.sessionRecording.upload.enabled }}
+    {{- $recBucket = .Values.sessionRecording.upload.s3Bucket }}
+    {{- $recPrefix = .Values.sessionRecording.upload.s3Prefix }}
+    {{- $recRegion = .Values.sessionRecording.upload.s3Region }}
+    {{- $recKeyId = .Values.sessionRecording.upload.s3AccessKeyId }}
+    {{- $recKeySecret = .Values.sessionRecording.upload.s3AccessKeySecret }}
+    {{- $recEndpoint = .Values.sessionRecording.upload.s3Endpoint }}
+    {{- $recCompress = .Values.sessionRecording.upload.compress }}
+    {{- if .Values.sessionRecording.upload.sse }}
+      {{- $recSSEType = .Values.sessionRecording.upload.sse.type }}
+      {{- $recSSEKmsKey = .Values.sessionRecording.upload.sse.kmsKeyId }}
+    {{- end }}
+    {{- $recStatePath = .Values.sessionRecording.upload.uploaderStatePath }}
+  {{- end }}
 {{- end }}
+            - name: ENABLE_RECORDING_UPLOAD
+              value: {{ ternary "true" "false" $recEnabled | quote }}
+            - name: RECORDING_S3_BUCKET
+              value: {{ $recBucket | quote }}
+            - name: RECORDING_S3_PREFIX
+              value: {{ $recPrefix | quote }}
+            - name: RECORDING_S3_REGION
+              value: {{ $recRegion | quote }}
+            - name: RECORDING_S3_ACCESS_KEY_ID
+              value: {{ $recKeyId | quote }}
+            - name: RECORDING_S3_ACCESS_KEY_SECRET
+              value: {{ $recKeySecret | quote }}
+            - name: RECORDING_S3_ENDPOINT
+              value: {{ $recEndpoint | quote }}
+            - name: RECORDING_COMPRESS
+              value: {{ ternary "true" "false" $recCompress | quote }}
+            - name: RECORDING_SSE_TYPE
+              value: {{ $recSSEType | quote }}
+            - name: RECORDING_SSE_KMS_KEY_ID
+              value: {{ $recSSEKmsKey | quote }}
+            {{- if $recStatePath }}
+            - name: RECORDING_UPLOADER_STATE_PATH
+              value: {{ $recStatePath | quote }}
+            {{- end }}
 {{- if .Values.dispatcher.env }}
           {{- toYaml .Values.dispatcher.env | nindent 12 }}
 {{- end }}

--- a/charts/akeyless-zero-trust-web-access/templates/dispatcher-deployment.yaml
+++ b/charts/akeyless-zero-trust-web-access/templates/dispatcher-deployment.yaml
@@ -182,7 +182,11 @@ spec:
             - name: no_proxy
               value: {{ .Values.httpProxySettings.no_proxy }}
 {{- end }}
-{{- /* Recording env: precedence is dispatcher.config.recording (service override) > sessionRecording.upload (unified) */}}
+{{- /* Recording env: precedence is per-field — dispatcher.config.recording.<field>
+     (service override) > sessionRecording.upload.<field> (unified) > built-in default.
+     Mirrors the per-field pattern used by web-worker-deployment so a stub
+     `dispatcher.config.recording: {}` block in values.yaml does NOT swallow the
+     unified sessionRecording.upload.* values. */}}
 {{- $recEnabled := false }}
 {{- $recBucket := "" }}
 {{- $recPrefix := "" }}
@@ -194,36 +198,35 @@ spec:
 {{- $recSSEType := "" }}
 {{- $recSSEKmsKey := "" }}
 {{- $recStatePath := "" }}
-{{- if .Values.dispatcher.config.recording }}
-  {{- /* Service-specific override takes precedence */}}
-  {{- $recEnabled = .Values.dispatcher.config.recording.enabled }}
-  {{- $recBucket = .Values.dispatcher.config.recording.s3Bucket }}
-  {{- $recPrefix = .Values.dispatcher.config.recording.s3Prefix }}
-  {{- $recRegion = .Values.dispatcher.config.recording.s3Region }}
-  {{- $recKeyId = .Values.dispatcher.config.recording.s3AccessKeyId }}
-  {{- $recKeySecret = .Values.dispatcher.config.recording.s3AccessKeySecret }}
-  {{- $recEndpoint = .Values.dispatcher.config.recording.s3Endpoint }}
-  {{- $recCompress = .Values.dispatcher.config.recording.compress }}
-  {{- $recSSEType = .Values.dispatcher.config.recording.sseType }}
-  {{- $recSSEKmsKey = .Values.dispatcher.config.recording.sseKmsKeyId }}
-  {{- $recStatePath = .Values.dispatcher.config.recording.uploaderStatePath }}
-{{- else if .Values.sessionRecording }}
-  {{- /* Fallback to unified configuration */}}
-  {{- if .Values.sessionRecording.upload }}
-    {{- $recEnabled = .Values.sessionRecording.upload.enabled }}
-    {{- $recBucket = .Values.sessionRecording.upload.s3Bucket }}
-    {{- $recPrefix = .Values.sessionRecording.upload.s3Prefix }}
-    {{- $recRegion = .Values.sessionRecording.upload.s3Region }}
-    {{- $recKeyId = .Values.sessionRecording.upload.s3AccessKeyId }}
-    {{- $recKeySecret = .Values.sessionRecording.upload.s3AccessKeySecret }}
-    {{- $recEndpoint = .Values.sessionRecording.upload.s3Endpoint }}
-    {{- $recCompress = .Values.sessionRecording.upload.compress }}
-    {{- if .Values.sessionRecording.upload.sse }}
-      {{- $recSSEType = .Values.sessionRecording.upload.sse.type }}
-      {{- $recSSEKmsKey = .Values.sessionRecording.upload.sse.kmsKeyId }}
-    {{- end }}
-    {{- $recStatePath = .Values.sessionRecording.upload.uploaderStatePath }}
+{{- if and .Values.sessionRecording .Values.sessionRecording.upload }}
+  {{- $u := .Values.sessionRecording.upload }}
+  {{- if hasKey $u "enabled" }}{{- $recEnabled = $u.enabled }}{{- end }}
+  {{- if $u.s3Bucket }}{{- $recBucket = $u.s3Bucket }}{{- end }}
+  {{- if $u.s3Prefix }}{{- $recPrefix = $u.s3Prefix }}{{- end }}
+  {{- if $u.s3Region }}{{- $recRegion = $u.s3Region }}{{- end }}
+  {{- if $u.s3AccessKeyId }}{{- $recKeyId = $u.s3AccessKeyId }}{{- end }}
+  {{- if $u.s3AccessKeySecret }}{{- $recKeySecret = $u.s3AccessKeySecret }}{{- end }}
+  {{- if $u.s3Endpoint }}{{- $recEndpoint = $u.s3Endpoint }}{{- end }}
+  {{- if hasKey $u "compress" }}{{- $recCompress = $u.compress }}{{- end }}
+  {{- if $u.sse }}
+    {{- if $u.sse.type }}{{- $recSSEType = $u.sse.type }}{{- end }}
+    {{- if $u.sse.kmsKeyId }}{{- $recSSEKmsKey = $u.sse.kmsKeyId }}{{- end }}
   {{- end }}
+  {{- if $u.uploaderStatePath }}{{- $recStatePath = $u.uploaderStatePath }}{{- end }}
+{{- end }}
+{{- if .Values.dispatcher.config.recording }}
+  {{- $r := .Values.dispatcher.config.recording }}
+  {{- if hasKey $r "enabled" }}{{- $recEnabled = $r.enabled }}{{- end }}
+  {{- if $r.s3Bucket }}{{- $recBucket = $r.s3Bucket }}{{- end }}
+  {{- if $r.s3Prefix }}{{- $recPrefix = $r.s3Prefix }}{{- end }}
+  {{- if $r.s3Region }}{{- $recRegion = $r.s3Region }}{{- end }}
+  {{- if $r.s3AccessKeyId }}{{- $recKeyId = $r.s3AccessKeyId }}{{- end }}
+  {{- if $r.s3AccessKeySecret }}{{- $recKeySecret = $r.s3AccessKeySecret }}{{- end }}
+  {{- if $r.s3Endpoint }}{{- $recEndpoint = $r.s3Endpoint }}{{- end }}
+  {{- if hasKey $r "compress" }}{{- $recCompress = $r.compress }}{{- end }}
+  {{- if $r.sseType }}{{- $recSSEType = $r.sseType }}{{- end }}
+  {{- if $r.sseKmsKeyId }}{{- $recSSEKmsKey = $r.sseKmsKeyId }}{{- end }}
+  {{- if $r.uploaderStatePath }}{{- $recStatePath = $r.uploaderStatePath }}{{- end }}
 {{- end }}
             - name: ENABLE_RECORDING_UPLOAD
               value: {{ ternary "true" "false" $recEnabled | quote }}

--- a/charts/akeyless-zero-trust-web-access/templates/dispatcher-deployment.yaml
+++ b/charts/akeyless-zero-trust-web-access/templates/dispatcher-deployment.yaml
@@ -191,21 +191,20 @@ spec:
 {{- $recBucket := "" }}
 {{- $recPrefix := "" }}
 {{- $recRegion := "" }}
-{{- $recKeyId := "" }}
-{{- $recKeySecret := "" }}
 {{- $recEndpoint := "" }}
 {{- $recCompress := false }}
 {{- $recSSEType := "" }}
 {{- $recSSEKmsKey := "" }}
 {{- $recStatePath := "" }}
+{{- $recSecretName := "" }}
+{{- $recSecretAccessKeyIdKey := "access-key-id" }}
+{{- $recSecretAccessKeySecretKey := "secret-access-key" }}
 {{- if and .Values.sessionRecording .Values.sessionRecording.upload }}
   {{- $u := .Values.sessionRecording.upload }}
   {{- if hasKey $u "enabled" }}{{- $recEnabled = $u.enabled }}{{- end }}
   {{- if $u.s3Bucket }}{{- $recBucket = $u.s3Bucket }}{{- end }}
   {{- if $u.s3Prefix }}{{- $recPrefix = $u.s3Prefix }}{{- end }}
   {{- if $u.s3Region }}{{- $recRegion = $u.s3Region }}{{- end }}
-  {{- if $u.s3AccessKeyId }}{{- $recKeyId = $u.s3AccessKeyId }}{{- end }}
-  {{- if $u.s3AccessKeySecret }}{{- $recKeySecret = $u.s3AccessKeySecret }}{{- end }}
   {{- if $u.s3Endpoint }}{{- $recEndpoint = $u.s3Endpoint }}{{- end }}
   {{- if hasKey $u "compress" }}{{- $recCompress = $u.compress }}{{- end }}
   {{- if $u.sse }}
@@ -213,6 +212,11 @@ spec:
     {{- if $u.sse.kmsKeyId }}{{- $recSSEKmsKey = $u.sse.kmsKeyId }}{{- end }}
   {{- end }}
   {{- if $u.uploaderStatePath }}{{- $recStatePath = $u.uploaderStatePath }}{{- end }}
+  {{- if $u.existingSecretNames }}
+    {{- if $u.existingSecretNames.s3 }}{{- $recSecretName = $u.existingSecretNames.s3 }}{{- end }}
+    {{- if $u.existingSecretNames.s3AccessKeyIdKey }}{{- $recSecretAccessKeyIdKey = $u.existingSecretNames.s3AccessKeyIdKey }}{{- end }}
+    {{- if $u.existingSecretNames.s3SecretAccessKeyKey }}{{- $recSecretAccessKeySecretKey = $u.existingSecretNames.s3SecretAccessKeyKey }}{{- end }}
+  {{- end }}
 {{- end }}
 {{- if .Values.dispatcher.config.recording }}
   {{- $r := .Values.dispatcher.config.recording }}
@@ -220,8 +224,6 @@ spec:
   {{- if $r.s3Bucket }}{{- $recBucket = $r.s3Bucket }}{{- end }}
   {{- if $r.s3Prefix }}{{- $recPrefix = $r.s3Prefix }}{{- end }}
   {{- if $r.s3Region }}{{- $recRegion = $r.s3Region }}{{- end }}
-  {{- if $r.s3AccessKeyId }}{{- $recKeyId = $r.s3AccessKeyId }}{{- end }}
-  {{- if $r.s3AccessKeySecret }}{{- $recKeySecret = $r.s3AccessKeySecret }}{{- end }}
   {{- if $r.s3Endpoint }}{{- $recEndpoint = $r.s3Endpoint }}{{- end }}
   {{- if hasKey $r "compress" }}{{- $recCompress = $r.compress }}{{- end }}
   {{- if $r.sseType }}{{- $recSSEType = $r.sseType }}{{- end }}
@@ -236,10 +238,18 @@ spec:
               value: {{ $recPrefix | quote }}
             - name: RECORDING_S3_REGION
               value: {{ $recRegion | quote }}
+{{- if $recSecretName }}
             - name: RECORDING_S3_ACCESS_KEY_ID
-              value: {{ $recKeyId | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $recSecretName | quote }}
+                  key: {{ $recSecretAccessKeyIdKey | quote }}
             - name: RECORDING_S3_ACCESS_KEY_SECRET
-              value: {{ $recKeySecret | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $recSecretName | quote }}
+                  key: {{ $recSecretAccessKeySecretKey | quote }}
+{{- end }}
             - name: RECORDING_S3_ENDPOINT
               value: {{ $recEndpoint | quote }}
             - name: RECORDING_COMPRESS

--- a/charts/akeyless-zero-trust-web-access/templates/validator.yaml
+++ b/charts/akeyless-zero-trust-web-access/templates/validator.yaml
@@ -25,6 +25,10 @@ spec:
         runAsGroup: 1000
         runAsNonRoot: true
         allowPrivilegeEscalation: false
+      {{- with .Values.validator.resources }}
+      resources:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       command: ["/bin/sh"]
       args:
           - "-c"

--- a/charts/akeyless-zero-trust-web-access/templates/web-worker-deployment.yaml
+++ b/charts/akeyless-zero-trust-web-access/templates/web-worker-deployment.yaml
@@ -148,12 +148,22 @@ spec:
             - name: DISPLAY_HEIGHT
               value: {{ .Values.webWorker.config.displayHeight | quote }}
           {{- end }}
-{{- with .Values.webWorker.config.recording }}
-            - name: ENABLE_RECORDING
-              value: {{ ternary "true" "false" .enabled }}
-            - name: RECORDING_QUALITY
-              value: {{ .quality | quote }}
+{{- /* Recording env: precedence is webWorker.config.recording (service override) > sessionRecording (unified) */}}
+{{- $workerRecEnabled := false }}
+{{- $workerRecQuality := "360p" }}
+{{- if .Values.webWorker.config.recording }}
+  {{- /* Service-specific override takes precedence */}}
+  {{- $workerRecEnabled = .Values.webWorker.config.recording.enabled }}
+  {{- $workerRecQuality = .Values.webWorker.config.recording.quality }}
+{{- else if .Values.sessionRecording }}
+  {{- /* Fallback to unified configuration */}}
+  {{- $workerRecEnabled = .Values.sessionRecording.enabled }}
+  {{- $workerRecQuality = .Values.sessionRecording.quality }}
 {{- end }}
+            - name: ENABLE_RECORDING
+              value: {{ ternary "true" "false" $workerRecEnabled | quote }}
+            - name: RECORDING_QUALITY
+              value: {{ $workerRecQuality | quote }}
 {{- if .Values.webWorker.env }}
           {{- toYaml .Values.webWorker.env | nindent 12 }}
 {{- end }}

--- a/charts/akeyless-zero-trust-web-access/templates/web-worker-deployment.yaml
+++ b/charts/akeyless-zero-trust-web-access/templates/web-worker-deployment.yaml
@@ -168,6 +168,28 @@ spec:
               value: {{ ternary "true" "false" $workerRecEnabled | quote }}
             - name: RECORDING_QUALITY
               value: {{ $workerRecQuality | quote }}
+{{- /* Lifecycle watchdog tunables. Each is rendered only when the operator
+       sets a non-empty string under sessionRecording.watchdog.*; otherwise
+       the in-image defaults (config.go: clientConnectTimeoutSeconds=90,
+       intervalSeconds=30s, maxDurationSeconds=4h) take effect. Required
+       to defend against "browser opened but client never connected" pods
+       and runaway recordings — see ASM-17214 lifecycle gaps. */}}
+{{- if and .Values.sessionRecording .Values.sessionRecording.watchdog }}
+  {{- with .Values.sessionRecording.watchdog }}
+    {{- if .clientConnectTimeoutSeconds }}
+            - name: WORKER_CLIENT_CONNECT_TIMEOUT_SECONDS
+              value: {{ .clientConnectTimeoutSeconds | quote }}
+    {{- end }}
+    {{- if .intervalSeconds }}
+            - name: SESSION_RECORDER_WATCHDOG_INTERVAL
+              value: {{ .intervalSeconds | quote }}
+    {{- end }}
+    {{- if .maxDurationSeconds }}
+            - name: SESSION_RECORDER_WATCHDOG_MAX_DURATION
+              value: {{ .maxDurationSeconds | quote }}
+    {{- end }}
+  {{- end }}
+{{- end }}
 {{- if .Values.webWorker.env }}
           {{- toYaml .Values.webWorker.env | nindent 12 }}
 {{- end }}

--- a/charts/akeyless-zero-trust-web-access/templates/web-worker-deployment.yaml
+++ b/charts/akeyless-zero-trust-web-access/templates/web-worker-deployment.yaml
@@ -190,6 +190,14 @@ spec:
     {{- end }}
   {{- end }}
 {{- end }}
+{{- /* Liveness-probe tunable: how long /tmp/occupied may exist without a
+       VNC client before the in-image probe wipes markers and recycles the
+       pod. Hardcoded default in the script is 30s; override here only if
+       your sessions need a longer warm-up window. */}}
+{{- if and .Values.webWorker.sessionCleanup .Values.webWorker.sessionCleanup.staleGraceSeconds }}
+            - name: STALE_GRACE_SECONDS
+              value: {{ .Values.webWorker.sessionCleanup.staleGraceSeconds | quote }}
+{{- end }}
 {{- if .Values.webWorker.env }}
           {{- toYaml .Values.webWorker.env | nindent 12 }}
 {{- end }}
@@ -211,21 +219,17 @@ spec:
 {{- end }}
           resources:
 {{- toYaml .Values.webWorker.resources | nindent 12 }}
+          # The probe script lives inside the image at
+          # /var/akeyless/scripts/worker_liveness.sh and is version-locked to
+          # web_worker_agent's clearSessionMarkers() contract. Operators tune
+          # behaviour through `webWorker.sessionCleanup.staleGraceSeconds`
+          # (passed via env) and the kubelet-side knobs under
+          # `webWorker.livenessProbe.*` (period, threshold, etc.) — never by
+          # editing the script itself.
           livenessProbe:
             exec:
               command:
-                - sh
-                - -c
-                - |
-                  RESP=$(curl -sf -o /dev/null -w "%{http_code}" http://localhost:9090/healthy 2>/dev/null)
-                  if [ -z "$RESP" ] || [ "$RESP" = "000" ]; then exit 1; fi
-                  if [ ! -f /tmp/occupied ]; then exit 0; fi
-                  AGE=$(( $(date +%s) - $(stat -c %Y /tmp/occupied) ))
-                  if [ $AGE -lt {{ .Values.webWorker.sessionCleanup.staleGraceSeconds | default 120 }} ]; then exit 0; fi
-                  if netstat -tn 2>/dev/null | grep -q ":5800.*ESTABLISHED"; then exit 0; fi
-                  rm -f /tmp/occupied /tmp/session /tmp/lock
-                  pkill -f web_worker_agent 2>/dev/null
-                  exit 1
+                - /var/akeyless/scripts/worker_liveness.sh
 {{- toYaml .Values.webWorker.livenessProbe | trim | nindent 12 }}
           lifecycle:
             preStop:

--- a/charts/akeyless-zero-trust-web-access/templates/web-worker-deployment.yaml
+++ b/charts/akeyless-zero-trust-web-access/templates/web-worker-deployment.yaml
@@ -148,17 +148,21 @@ spec:
             - name: DISPLAY_HEIGHT
               value: {{ .Values.webWorker.config.displayHeight | quote }}
           {{- end }}
-{{- /* Recording env: precedence is webWorker.config.recording (service override) > sessionRecording (unified) */}}
+{{- /* Recording env: precedence per-field is webWorker.config.recording.<field> (service
+     override) > sessionRecording.<field> (unified) > built-in default. */}}
 {{- $workerRecEnabled := false }}
 {{- $workerRecQuality := "360p" }}
-{{- if .Values.webWorker.config.recording }}
-  {{- /* Service-specific override takes precedence */}}
-  {{- $workerRecEnabled = .Values.webWorker.config.recording.enabled }}
-  {{- $workerRecQuality = .Values.webWorker.config.recording.quality }}
-{{- else if .Values.sessionRecording }}
-  {{- /* Fallback to unified configuration */}}
+{{- if .Values.sessionRecording }}
   {{- $workerRecEnabled = .Values.sessionRecording.enabled }}
   {{- $workerRecQuality = .Values.sessionRecording.quality }}
+{{- end }}
+{{- if .Values.webWorker.config.recording }}
+  {{- if hasKey .Values.webWorker.config.recording "enabled" }}
+    {{- $workerRecEnabled = .Values.webWorker.config.recording.enabled }}
+  {{- end }}
+  {{- if .Values.webWorker.config.recording.quality }}
+    {{- $workerRecQuality = .Values.webWorker.config.recording.quality }}
+  {{- end }}
 {{- end }}
             - name: ENABLE_RECORDING
               value: {{ ternary "true" "false" $workerRecEnabled | quote }}

--- a/charts/akeyless-zero-trust-web-access/templates/web-worker-deployment.yaml
+++ b/charts/akeyless-zero-trust-web-access/templates/web-worker-deployment.yaml
@@ -148,6 +148,12 @@ spec:
             - name: DISPLAY_HEIGHT
               value: {{ .Values.webWorker.config.displayHeight | quote }}
           {{- end }}
+{{- with .Values.webWorker.config.recording }}
+            - name: ENABLE_RECORDING
+              value: {{ ternary "true" "false" .enabled }}
+            - name: RECORDING_QUALITY
+              value: {{ .quality | quote }}
+{{- end }}
 {{- if .Values.webWorker.env }}
           {{- toYaml .Values.webWorker.env | nindent 12 }}
 {{- end }}

--- a/charts/akeyless-zero-trust-web-access/values.yaml
+++ b/charts/akeyless-zero-trust-web-access/values.yaml
@@ -351,9 +351,28 @@ webWorker:
   #   limits:
   #     memory: 4Gi
 
+  # Two layers of session-cleanup defence on the worker:
+  #
+  # 1. The web_worker_agent itself removes /tmp/occupied as soon as `/healthy`
+  #    detects that the VNC client closed the connection (clearSessionMarkers()
+  #    in handlers/register_handlers/server.go). This is the fast path — no
+  #    pod recycle is needed and the worker re-enters the dispatcher pool on
+  #    the next /healthy poll (~30s after the user closes the tab).
+  # 2. The liveness probe below is the *safety net* for the case where the
+  #    agent process itself dies. Once `/tmp/occupied` is older than
+  #    sessionCleanup.staleGraceSeconds AND no client is on :5800, the probe
+  #    wipes the markers and signals kubelet to recycle the pod.
   sessionCleanup:
+    # How long to wait after `/tmp/occupied` is created before the probe is
+    # allowed to declare the worker stranded. Must cover the worst-case
+    # browser-mount latency (token exchange + Firefox render). 30s is enough
+    # for a healthy network; raise if your sessions need >30s warm-up.
     staleGraceSeconds: 30
 
+  # Tighter defaults than the chart used to ship with: failureThreshold * periodSeconds
+  # is the upper bound on how long a dead-agent pod stays stranded. With these values,
+  # recycle happens within ~30 seconds of the third consecutive failure, vs. the older
+  # 60 * 30s = 30-minute window that hid the ASM-17214 lifecycle regression.
   livenessProbe:
     initialDelaySeconds: 60
     periodSeconds: 10

--- a/charts/akeyless-zero-trust-web-access/values.yaml
+++ b/charts/akeyless-zero-trust-web-access/values.yaml
@@ -77,6 +77,30 @@ sessionRecording:
     # Default: upload/recording_uploader_state.json (under /etc/shared)
     uploaderStatePath: ""
 
+  # Worker-side lifecycle watchdog configuration
+  # These knobs cap a single recording's wall-clock duration and detect
+  # "browser tab opened but client never connected" abort scenarios.
+  # The defaults are safe for typical interactive sessions; extend
+  # maxDurationSeconds for environments with very long-running screens
+  # (e.g. 24/7 dashboards). Empty string keeps the in-image defaults.
+  watchdog:
+    # WORKER_CLIENT_CONNECT_TIMEOUT_SECONDS — how long the worker waits for
+    # the browser to actually establish a websocket on :5800 after the
+    # session is assigned. If the client never appears, the worker tears
+    # down the session so the liveness probe can recycle the pod.
+    # In-image default: 90 seconds.
+    clientConnectTimeoutSeconds: ""
+    # SESSION_RECORDER_WATCHDOG_INTERVAL — how often the recorder watchdog
+    # wakes up to check the max-duration cap. Tune lower (e.g. "10s") for
+    # tighter recycling, higher to reduce wake-ups.
+    # In-image default: 30s. Format: Go duration string ("10s", "1m", ...).
+    intervalSeconds: ""
+    # SESSION_RECORDER_WATCHDOG_MAX_DURATION — hard upper bound on a single
+    # recording's wall-clock duration. The watchdog issues a graceful Stop
+    # when exceeded so the dispatcher can finalise the MKV and upload.
+    # In-image default: 4h. Format: Go duration string ("4h", "8h", ...).
+    maxDurationSeconds: ""
+
 validator:
   # Validator is enabled by default, and will run on helm chart installation.
   # If Validator set to false, policies validation will still run on the web-worker deployment, with the validator as init-container.

--- a/charts/akeyless-zero-trust-web-access/values.yaml
+++ b/charts/akeyless-zero-trust-web-access/values.yaml
@@ -34,10 +34,12 @@ deployment:
 # Advanced users can override specific settings via dispatcher.config.recording.* and webWorker.config.recording.*
 # Requires persistence.shareStorageVolume configured with ReadWriteMany access mode.
 sessionRecording:
-  # Enable video capture on web-worker pods (creates rec_*.mp4 files in shared volume)
+  # Enable video capture on web-worker pods.
+  # Worker writes Matroska (rec_*.mkv) to the shared volume; dispatcher remuxes to standard
+  # rec_*.mp4 with ffmpeg before S3 upload. The customer-facing artifact in S3 stays .mp4.
   enabled: false
   
-  # Recording quality: 144p|240p|360p|480p|720p|1080p (affects vnc-recorder CRF and framerate)
+  # Recording quality: 144p|240p|360p|480p|720p|1080p (affects ffmpeg CRF and framerate)
   quality: "360p"
   
   # S3 upload configuration (dispatcher-side)
@@ -264,22 +266,17 @@ dispatcher:
 #      target_splunk_token=""
 #      target_splunk_url=""
 
-    # Session recording upload (dispatcher recording_uploader). Requires persistence.shareStorageVolume so /etc/shared exists.
-    # When enabled is false the uploader exits on start; set S3 settings when enabling. Credentials may instead come from
-    # LOG_FORWARDING / logand.conf (target_log_type=aws_s3) when bucket keys are empty — see dispatcher env documentation.
-    recording:
-      enabled: false
-      s3Bucket: ""
-      s3Prefix: ""
-      s3Region: ""
-      s3AccessKeyId: ""
-      s3AccessKeySecret: ""
-      s3Endpoint: ""
-      compress: false
-      sseType: ""
-      sseKmsKeyId: ""
-      # Optional JSON state path (default upload/recording_uploader_state.json under /etc/shared). Absolute or relative to /etc/shared.
-      uploaderStatePath: ""
+    # Service-specific override for session recording upload. Empty by default;
+    # any field set here takes precedence over the equivalent sessionRecording.upload.<field>
+    # for the dispatcher only. Recognised fields: enabled, s3Bucket, s3Prefix, s3Region,
+    # s3AccessKeyId, s3AccessKeySecret, s3Endpoint, compress, sseType, sseKmsKeyId,
+    # uploaderStatePath. Use this to drive a different bucket or credentials than
+    # the unified config when running multiple ZTWA fleets from one chart.
+    # Example:
+    #   recording:
+    #     s3Bucket: high-priority-bucket
+    #     s3Region: eu-west-1
+    recording: {}
 
 webWorker:
   replicaCount: 5
@@ -346,10 +343,13 @@ webWorker:
     displayWidth: 2560
     displayHeight: 1200
 
-    # Firefox session recording quality (vnc-recorder). Requires persistence.shareStorageVolume for recordings path.
-    recording:
-      enabled: false
-      quality: "360p"
+    # Service-specific override for session recording capture (worker only).
+    # Empty by default; any field set here takes precedence over the equivalent
+    # sessionRecording.<field> for the worker. Recognised fields: enabled, quality.
+    # Example for a higher-quality worker pool:
+    #   recording:
+    #     quality: "720p"
+    recording: {}
 
     policies: |
         {

--- a/charts/akeyless-zero-trust-web-access/values.yaml
+++ b/charts/akeyless-zero-trust-web-access/values.yaml
@@ -218,6 +218,23 @@ dispatcher:
 #      target_splunk_token=""
 #      target_splunk_url=""
 
+    # Session recording upload (dispatcher recording_uploader). Requires persistence.shareStorageVolume so /etc/shared exists.
+    # When enabled is false the uploader exits on start; set S3 settings when enabling. Credentials may instead come from
+    # LOG_FORWARDING / logand.conf (target_log_type=aws_s3) when bucket keys are empty — see dispatcher env documentation.
+    recording:
+      enabled: false
+      s3Bucket: ""
+      s3Prefix: ""
+      s3Region: ""
+      s3AccessKeyId: ""
+      s3AccessKeySecret: ""
+      s3Endpoint: ""
+      compress: false
+      sseType: ""
+      sseKmsKeyId: ""
+      # Optional JSON state path for recording_uploader (default file under /etc/shared). Absolute or relative to /etc/shared.
+      uploaderStatePath: ""
+
 webWorker:
   replicaCount: 5
   initContainer:
@@ -282,6 +299,11 @@ webWorker:
   config:
     displayWidth: 2560
     displayHeight: 1200
+
+    # Firefox session recording quality (vnc-recorder). Requires persistence.shareStorageVolume for recordings path.
+    recording:
+      enabled: false
+      quality: "360p"
 
     policies: |
         {

--- a/charts/akeyless-zero-trust-web-access/values.yaml
+++ b/charts/akeyless-zero-trust-web-access/values.yaml
@@ -29,6 +29,52 @@ httpProxySettings:
 deployment:
   labels: {}
 
+# Session recording (unified configuration - recommended)
+# Provides a simplified interface for enabling video capture and S3 upload.
+# Advanced users can override specific settings via dispatcher.config.recording.* and webWorker.config.recording.*
+# Requires persistence.shareStorageVolume configured with ReadWriteMany access mode.
+sessionRecording:
+  # Enable video capture on web-worker pods (creates rec_*.mp4 files in shared volume)
+  enabled: false
+  
+  # Recording quality: 144p|240p|360p|480p|720p|1080p (affects vnc-recorder CRF and framerate)
+  quality: "360p"
+  
+  # S3 upload configuration (dispatcher-side)
+  upload:
+    # Enable upload to S3-compatible storage (requires valid credentials and bucket config)
+    enabled: false
+    
+    # S3 bucket and region (required when upload.enabled is true)
+    s3Bucket: ""
+    s3Region: ""
+    
+    # Optional S3 prefix for organizing recordings (e.g., "recordings" or "ztwa/sessions")
+    s3Prefix: ""
+    
+    # Optional custom endpoint for S3-compatible services (MinIO, Wasabi, NetApp StorageGRID, etc.)
+    # Leave empty for AWS S3
+    s3Endpoint: ""
+    
+    # S3 credentials (NOT RECOMMENDED: use secretKeyRef in dispatcher.env or IAM/IRSA instead)
+    # Leave empty to use AWS default credential chain (instance profile, environment, etc.)
+    s3AccessKeyId: ""
+    s3AccessKeySecret: ""
+    
+    # Enable gzip compression before upload (reduces storage/bandwidth costs)
+    compress: false
+    
+    # Server-side encryption configuration
+    sse:
+      # Encryption type: "" (none), "sse-s3" (AES-256), or "sse-kms"
+      type: ""
+      # KMS key ID/ARN (required for sse-kms, optional to use default CMK)
+      kmsKeyId: ""
+    
+    # Optional: Custom path for upload state file (absolute or relative to /etc/shared)
+    # Default: upload/recording_uploader_state.json (under /etc/shared)
+    uploaderStatePath: ""
+
 validator:
   # Validator is enabled by default, and will run on helm chart installation.
   # If Validator set to false, policies validation will still run on the web-worker deployment, with the validator as init-container.
@@ -232,7 +278,7 @@ dispatcher:
       compress: false
       sseType: ""
       sseKmsKeyId: ""
-      # Optional JSON state path for recording_uploader (default file under /etc/shared). Absolute or relative to /etc/shared.
+      # Optional JSON state path (default upload/recording_uploader_state.json under /etc/shared). Absolute or relative to /etc/shared.
       uploaderStatePath: ""
 
 webWorker:

--- a/charts/akeyless-zero-trust-web-access/values.yaml
+++ b/charts/akeyless-zero-trust-web-access/values.yaml
@@ -117,6 +117,12 @@ validator:
   # For Example when using istio sidecar to avoid issues with validator job completion please add the following annotation:
   #  annotations:
   #    sidecar.istio.io/inject: "false"
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      memory: 512Mi
 
 
 dispatcher:

--- a/charts/akeyless-zero-trust-web-access/values.yaml
+++ b/charts/akeyless-zero-trust-web-access/values.yaml
@@ -58,10 +58,21 @@ sessionRecording:
     # Leave empty for AWS S3
     s3Endpoint: ""
     
-    # S3 credentials (NOT RECOMMENDED: use secretKeyRef in dispatcher.env or IAM/IRSA instead)
-    # Leave empty to use AWS default credential chain (instance profile, environment, etc.)
-    s3AccessKeyId: ""
-    s3AccessKeySecret: ""
+    # S3 credentials are sourced from a Kubernetes Secret you create out-of-band
+    # (or from the AWS default credential chain if existingSecretNames.s3 is empty:
+    # IRSA, instance profile, AWS_* env vars from dispatcher.env, etc.).
+    #
+    # Example:
+    #   kubectl create secret generic ztwa-s3-credentials \
+    #     --from-literal=access-key-id=AKIA... \
+    #     --from-literal=secret-access-key=...
+    existingSecretNames:
+      # Name of the Secret holding the S3 credential pair.
+      # When empty, the chart falls back to the AWS default credential chain.
+      s3: ""
+      # Keys inside that Secret. Defaults align with the kubectl example above.
+      s3AccessKeyIdKey: "access-key-id"
+      s3SecretAccessKeyKey: "secret-access-key"
     
     # Enable gzip compression before upload (reduces storage/bandwidth costs)
     compress: false
@@ -299,9 +310,10 @@ dispatcher:
     # Service-specific override for session recording upload. Empty by default;
     # any field set here takes precedence over the equivalent sessionRecording.upload.<field>
     # for the dispatcher only. Recognised fields: enabled, s3Bucket, s3Prefix, s3Region,
-    # s3AccessKeyId, s3AccessKeySecret, s3Endpoint, compress, sseType, sseKmsKeyId,
-    # uploaderStatePath. Use this to drive a different bucket or credentials than
-    # the unified config when running multiple ZTWA fleets from one chart.
+    # s3Endpoint, compress, sseType, sseKmsKeyId, uploaderStatePath. Credentials
+    # come exclusively from sessionRecording.upload.existingSecretNames.s3 — there
+    # is no per-dispatcher override for the credential pair, mount a different
+    # Secret if you need that.
     # Example:
     #   recording:
     #     s3Bucket: high-priority-bucket


### PR DESCRIPTION
## Summary

Adds first-class Helm support for ZTWA session recording (worker capture +
dispatcher S3 upload) and fixes a precedence bug where the legacy
`dispatcher.config.recording` block was silently swallowing the unified
`sessionRecording.upload.*` values.

The chart now exposes a single user-facing section — `sessionRecording.*`
— that drives both the worker recorder and the dispatcher uploader, with
optional per-field overrides on either service for advanced users.

## What changed

### `values.yaml`

* New top-level `sessionRecording` section (the recommended way):
  * `enabled` — turns on worker capture (`rec_*.mkv` on the shared volume)
    and dispatcher upload together.
  * `quality` — `144p|240p|360p|480p|720p|1080p` (drives ffmpeg CRF /
    framerate on the worker).
  * `upload.*` — S3 bucket / prefix / region / creds / endpoint /
    compress / SSE / `uploaderStatePath`.
* `dispatcher.config.recording` and `webWorker.config.recording` shrunk
  from full default blocks to `{}` with override examples in the
  comments. **This is the bugfix** — when those blocks shipped non-empty
  by default, the dispatcher template took them as a service override and
  silently overrode `sessionRecording.upload.*` whenever an operator
  enabled recording via the unified section.
* `sessionRecording` docstrings describe the new on-disk contract: worker
  writes `rec_*.mkv`, dispatcher remuxes to `rec_*.mp4` with `ffmpeg`
  before S3 upload — the customer-facing artifact in S3 stays `.mp4`.

### `templates/dispatcher-deployment.yaml`

Rewrites the recording-env precedence to **per-field**:

1. Read unified `sessionRecording.upload.<field>` (if set).
2. Overlay `dispatcher.config.recording.<field>` (if set, per field —
    via `hasKey` for booleans / `if $r.<field>` for strings).
3. Built-in defaults otherwise.

This mirrors the pattern already used by `web-worker-deployment.yaml` and
removes the trap where an empty/legacy override block always won. Boolean
env vars are rendered with `ternary | quote` to avoid the
`json: cannot unmarshal bool into …EnvVar.value` Helm error we hit on
older clusters.

### `templates/web-worker-deployment.yaml`

* Comment clarifies the per-field precedence.
* Splits the old `if/else` into two passes (read unified, then overlay
  per-field overrides) so the worker template is structurally identical
  to the dispatcher template.
* Same boolean-quoting fix as the dispatcher template.

### `README.md`

* Replaces the inaccurate "Partial Recordings" guidance (which used to
  say "increase staleGraceSeconds or accept truncated recordings") with
  the new MKV-on-disk + SIGTERM-flush + dispatcher-remux story.
* Drops the dangling reference to the (relocated) `BACKWARD_COMPAT_TEST.md`.
* Documents the `session_recorder` preflight (`/etc/shared` writable,
  `/bin/ffmpeg` executable) so operators recognise the fail-fast log line.

### `Chart.yaml`

* `version: 3.1.0 → 3.2.0` (new top-level value section + bugfix).

## Verification — `helm template` matrix

| Scenario | `ENABLE_RECORDING` (worker) | `ENABLE_RECORDING_UPLOAD` (disp.) | `RECORDING_S3_BUCKET` |
|---|---|---|---|
| **defaults** | `"false"` | `"false"` | `""` |
| **unified only** (`sessionRecording.enabled=true`, `sessionRecording.upload.s3Bucket=unified-bucket`) | `"true"` | `"true"` | `"unified-bucket"` ← was `""` before fix |
| **unified + per-field override** (`dispatcher.config.recording.s3Bucket=override-bucket`, `webWorker.config.recording.quality=720p`) | `"true"`, quality `"720p"` | `"true"` | `"override-bucket"` |

`helm lint` clean.

## Backward compatibility

Existing deployments using `dispatcher.config.recording.*` and
`webWorker.config.recording.*` continue to work — those fields still
override the unified section per-field. The only behavioural change is
that an **untouched** values.yaml no longer has a non-empty
`dispatcher.config.recording` block silently overriding
`sessionRecording.upload.*`. Operators who want the old behaviour can
re-add the explicit fields under `dispatcher.config.recording.*`.

## Test plan

* [ ] `helm lint charts/akeyless-zero-trust-web-access` (✅ done)
* [ ] `helm template` against the three scenarios above (✅ done — matrix
      in this PR)
* [ ] Install `3.2.0` on the k3s sandbox with new images from the
      linked `akeyless-miscellaneous` PR; trigger a session; verify
      playable `.mp4` lands in S3.
* [ ] Verify upgrade from `3.1.0` (where applicable) does not break
      existing deployments using legacy per-service config.

## Linked PR

* `akeyless-miscellaneous`:
  [ASM-17214-session-recording-support-for-s3upload-quality-compression](https://github.com/akeylesslabs/akeyless-miscellaneous/pull/115)
  (new `session_recorder` Go service, MKV-on-disk pivot, dispatcher remux,
  uploader hardening).

## Refs

* Jira: ASM-17214

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified optional session recording with cloud upload, configurable quality, compression, SSE/KMS, uploader state path, and per-service override precedence
  * Worker-side recording toggles and dispatcher-controlled upload settings; conditional credential handling

* **Documentation**
  * Expanded session recording guide: setup, single vs multi-node warning, precedence rules, upload behavior, watchdogs, troubleshooting, and examples

* **Chores**
  * Chart version bumped; validator resources made configurable; worker liveness probe updated to exec script
<!-- end of auto-generated comment: release notes by coderabbit.ai -->