### PR TITLE
[ASM-18124] akeyless-zero-trust-web-access: add dispatcher.config.cloudIdentity.type

### DIFF
--- a/charts/akeyless-zero-trust-web-access/Chart.yaml
+++ b/charts/akeyless-zero-trust-web-access/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart for Kubernetes that deploys akeyless-zero-trust-web-ac
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.2.1
+version: 3.3.0
 appVersion: 2.0.0-rc2
 icon: https://akeylesslabs.github.io/helm-charts/assets/logo/akl.jpeg
 home: https://www.akeyless.io

--- a/charts/akeyless-zero-trust-web-access/README.md
+++ b/charts/akeyless-zero-trust-web-access/README.md
@@ -199,7 +199,7 @@ The dispatcher upload service tries credentials in this order:
 
 Existing deployments using `dispatcher.config.recording.*` and `webWorker.config.recording.*` continue to function identically. The unified `sessionRecording.*` section is **opt-in** and recommended for new deployments.
 
-### Cloud Identity Escape Hatch (`dispatcher.config.cloudIdentity.type`)
+### Cloud Identity (`dispatcher.config.cloudIdentity.type`)
 
 The dispatcher determines its cloud provider by probing the instance
 metadata service at `169.254.169.254` (IMDS). When IMDS is unreachable,

--- a/charts/akeyless-zero-trust-web-access/README.md
+++ b/charts/akeyless-zero-trust-web-access/README.md
@@ -199,6 +199,39 @@ The dispatcher upload service tries credentials in this order:
 
 Existing deployments using `dispatcher.config.recording.*` and `webWorker.config.recording.*` continue to function identically. The unified `sessionRecording.*` section is **opt-in** and recommended for new deployments.
 
+### Cloud Identity Escape Hatch (`dispatcher.config.cloudIdentity.type`)
+
+The dispatcher determines its cloud provider by probing the instance
+metadata service at `169.254.169.254` (IMDS). When IMDS is unreachable,
+classification fails and sessions exit with `unknown-cloud-provider`.
+Common causes:
+
+- **EKS with IMDSv2 `httpPutResponseHopLimit=1`** (the AWS default — pods
+  cannot reach IMDS unless the limit is raised to `2` on the worker node).
+- Restrictive egress `NetworkPolicy` denying the link-local subnet.
+- Non-cloud Kubernetes (on-prem k3s, kind, bare metal).
+
+Set `dispatcher.config.cloudIdentity.type` to skip the IMDS probe and
+authenticate with the configured cloud identity directly:
+
+```yaml
+dispatcher:
+  config:
+    privilegedAccess:
+      accessID: "<AWS_IAM_ACCESS_ID>"
+      # accessKey: must be empty to take the cloud-identity code path
+    cloudIdentity:
+      type: "aws_iam"   # or "azure_ad" / "gcp"
+```
+
+Allowed values: `""` (default, IMDS auto-detection), `"aws_iam"`,
+`"azure_ad"`, `"gcp"`. The default `""` renders no `ADMIN_ACCESS_ID_TYPE`
+env var, so existing deployments are unaffected.
+
+For background on the IMDSv2 hop-limit issue and alternative mitigations
+(e.g. raising the hop limit at the EC2 level), see the
+[Akeyless AWS IAM guide](https://docs.akeyless.io/docs/auth-with-aws#aws-instance-metadata-service).
+
 ### Prerequisites
 
 #### Horizonal Auto-Scaling

--- a/charts/akeyless-zero-trust-web-access/README.md
+++ b/charts/akeyless-zero-trust-web-access/README.md
@@ -199,7 +199,7 @@ The dispatcher upload service tries credentials in this order:
 
 Existing deployments using `dispatcher.config.recording.*` and `webWorker.config.recording.*` continue to function identically. The unified `sessionRecording.*` section is **opt-in** and recommended for new deployments.
 
-### Cloud Identity (`dispatcher.config.cloudIdentity.type`)
+### Cloud Identity Override (`dispatcher.config.cloudIdentity.type`)
 
 The dispatcher determines its cloud provider by probing the instance
 metadata service at `169.254.169.254` (IMDS). When IMDS is unreachable,

--- a/charts/akeyless-zero-trust-web-access/templates/dispatcher-deployment.yaml
+++ b/charts/akeyless-zero-trust-web-access/templates/dispatcher-deployment.yaml
@@ -164,6 +164,10 @@ spec:
             - name: CLUSTER_NAME
               value: {{ .Values.dispatcher.config.clusterName }}
 {{- end }}
+{{- if and .Values.dispatcher.config.cloudIdentity .Values.dispatcher.config.cloudIdentity.type }}
+            - name: ADMIN_ACCESS_ID_TYPE
+              value: {{ .Values.dispatcher.config.cloudIdentity.type | quote }}
+{{- end }}
 {{- if .Values.httpProxySettings.http_proxy }}
             - name: HTTP_PROXY
               value: {{ .Values.httpProxySettings.http_proxy }}

--- a/charts/akeyless-zero-trust-web-access/values.schema.json
+++ b/charts/akeyless-zero-trust-web-access/values.schema.json
@@ -63,6 +63,24 @@
               }
             }
           }
+        },
+        "config": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "cloudIdentity": {
+              "type": "object",
+              "additionalProperties": true,
+              "description": "IMDS escape hatch for clusters where the dispatcher pod cannot reach 169.254.169.254 (e.g. EKS with IMDSv2 hop-limit=1).",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": ["", "aws_iam", "azure_ad", "gcp"],
+                  "description": "Set to short-circuit IMDS classification and authenticate via the configured cloud identity. Empty string (default) preserves IMDS auto-detection."
+                }
+              }
+            }
+          }
         }
       }
     },

--- a/charts/akeyless-zero-trust-web-access/values.schema.json
+++ b/charts/akeyless-zero-trust-web-access/values.schema.json
@@ -71,7 +71,7 @@
             "cloudIdentity": {
               "type": "object",
               "additionalProperties": true,
-              "description": "IMDS escape hatch for clusters where the dispatcher pod cannot reach 169.254.169.254 (e.g. EKS with IMDSv2 hop-limit=1).",
+              "description": "Cloud identity override. Forces the dispatcher to authenticate via the configured cloud identity instead of probing IMDS. Use this on clusters where the dispatcher pod cannot reach 169.254.169.254 (e.g. EKS with IMDSv2 hop-limit=1).",
               "properties": {
                 "type": {
                   "type": "string",

--- a/charts/akeyless-zero-trust-web-access/values.yaml
+++ b/charts/akeyless-zero-trust-web-access/values.yaml
@@ -286,10 +286,10 @@ dispatcher:
    # When false, dispatcher session cookie can be send only on top off encrypted requests (HTTPS)
     disableSecureCookie: "true"
 
-    # IMDS escape hatch. When set, the dispatcher skips cloud-provider detection
-    # via the instance metadata endpoint and authenticates with this access type
-    # directly. Use it on clusters where pods cannot reach 169.254.169.254
-    # (e.g. EKS with IMDSv2 httpPutResponseHopLimit=1, strict egress policies).
+    # Cloud identity override. Forces the dispatcher to authenticate via the
+    # configured cloud identity instead of probing IMDS. Use this on clusters
+    # where the dispatcher pod cannot reach 169.254.169.254 (e.g. EKS with
+    # IMDSv2 httpPutResponseHopLimit=1, strict egress policies).
     # Allowed values: "" (auto-detect via IMDS, default) | "aws_iam" | "azure_ad" | "gcp".
     # https://docs.akeyless.io/docs/auth-with-aws#aws-instance-metadata-service
     cloudIdentity:

--- a/charts/akeyless-zero-trust-web-access/values.yaml
+++ b/charts/akeyless-zero-trust-web-access/values.yaml
@@ -286,6 +286,15 @@ dispatcher:
    # When false, dispatcher session cookie can be send only on top off encrypted requests (HTTPS)
     disableSecureCookie: "true"
 
+    # IMDS escape hatch. When set, the dispatcher skips cloud-provider detection
+    # via the instance metadata endpoint and authenticates with this access type
+    # directly. Use it on clusters where pods cannot reach 169.254.169.254
+    # (e.g. EKS with IMDSv2 httpPutResponseHopLimit=1, strict egress policies).
+    # Allowed values: "" (auto-detect via IMDS, default) | "aws_iam" | "azure_ad" | "gcp".
+    # https://docs.akeyless.io/docs/auth-with-aws#aws-instance-metadata-service
+    cloudIdentity:
+      type: ""
+
     # existingLogForwardSecretName will hold the configuration for dispatcher log forward
     # The data structure in secret should be like so:
     ## logand.conf: | ## make sure to keep logand.conf as the key!


### PR DESCRIPTION
## Summary

Adds a first-class chart knob `dispatcher.config.cloudIdentity.type` that templates an `ADMIN_ACCESS_ID_TYPE` env var on the dispatcher container. This is the helm-side half of the ASM-18124 fix — the dispatcher image already has the corresponding bash logic in the companion PR; this PR exposes it as a user-facing chart option mirroring the gateway image's existing knob.

**Customer-blocking:** Cisco / Pavel Jimanov / EKS-A deployment. ZTWA sessions exit with `unknown-cloud-provider` when EC2 IMDSv2 has `httpPutResponseHopLimit=1` (AWS default).

## Files changed

- `charts/akeyless-zero-trust-web-access/values.yaml` — new field `dispatcher.config.cloudIdentity.type` (allowed: `""` default | `aws_iam` | `azure_ad` | `gcp`).
- `charts/akeyless-zero-trust-web-access/templates/dispatcher-deployment.yaml` — conditional env injection (only renders when the knob is non-empty).
- `charts/akeyless-zero-trust-web-access/Chart.yaml` — minor bump `3.2.1 → 3.3.0` (new user-facing knob).
- `charts/akeyless-zero-trust-web-access/README.md` — new "Cloud Identity Escape Hatch" subsection documenting the failure mode + mitigation.

## Risk: low

Default value `""` renders **no env var**, so existing deployments are unaffected. Empirically verified on a real sandbox (see Phase 2.4 below).

The template guard is:

\`\`\`gotemplate
{{- if and .Values.dispatcher.config.cloudIdentity .Values.dispatcher.config.cloudIdentity.type }}
            - name: ADMIN_ACCESS_ID_TYPE
              value: {{ .Values.dispatcher.config.cloudIdentity.type | quote }}
{{- end }}
\`\`\`

An empty value, a nil `cloudIdentity` field, or simply not setting the knob all suppress the env var.

## Test plan

### `helm template` rendering

| Scenario | Expected | Result |
|----------|----------|--------|
| Default (no knob) | no `ADMIN_ACCESS_ID_TYPE` rendered | OK |
| `cloudIdentity.type=aws_iam` | env rendered with value `"aws_iam"` | OK |
| `cloudIdentity.type=azure_ad` | env rendered with value `"azure_ad"` | OK |
| Knob + `dispatcher.env[]` override | both rendered; k8s last-wins gives env[] the win | OK |

`helm lint` passes.

### End-to-end on sandbox (`hanan-k3s-sandbox-mus-sra-gw`)

| Phase | Setup | Outcome |
|-------|-------|---------|
| **2 fix verified** | chart `3.3.0` + image `0.0.1-aws_iam` + `cloudIdentity.type=aws_iam` + `NetworkPolicy` blocking IMDS | dispatcher works (keepalive `privileged_creds_type: aws_iam`, no failure log). Real session opened via SRA portal against an isolated-browser secret — succeeded. |
| **2.4 backward compat** | chart `3.3.0` + image `0.0.1-aws_iam` + knob unset + IMDS reachable | identical to baseline with the stock chart + image — proves the chart bump is safe for existing customers |

## Companion PR

Dispatcher image bash patches: https://github.com/akeylesslabs/akeyless-miscellaneous/pull/new/ASM-18124-admin-access-id-type-parity

## Notes

- `appVersion` stays `2.0.0-rc2` for now. We will bump to `2.0.0-rc3` once the patched dispatcher image is published officially. Today the test image lives at `akeyless/zero-trust-web-dispatcher-dev:0.0.1-aws_iam` (built from the companion PR) and users can pin it via `dispatcher.image.tag`.
- Stale duplicate chart at `akeyless-plugins-repos/k8s-plugins/helm-charts/...` was intentionally **not** modified — its templates are already drifted from this canonical chart, clearly not the source of truth.

## Refs

- Jira: ASM-18124
- Docs (gateway-side IMDS hatch this PR mirrors for ZTWA): https://docs.akeyless.io/docs/auth-with-aws#aws-instance-metadata-service

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dispatcher cloud identity configuration to force a specific cloud provider identity (options: "", aws_iam, azure_ad, gcp).

* **Documentation**
  * Added a "Cloud Identity Escape Hatch" section with examples, failure scenarios, allowed values, and guidance for cloud IAM contexts.

* **Chores**
  * Helm chart version bumped to 3.3.0.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akeylesslabs/helm-charts/pull/376)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->