### PR TITLE
akeyless-gateway: add externalTrafficPolicy to SRA SSH service

### DIFF
--- a/charts/akeyless-gateway/Chart.yaml
+++ b/charts/akeyless-gateway/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: akeyless-gateway
-version: 2.0.0
+version: 2.0.1
 description: A Helm chart for Kubernetes that deploys akeyless-gateway
 type: application
 keywords:

--- a/charts/akeyless-gateway/templates/akeyless-secure-remote-access/service.yaml
+++ b/charts/akeyless-gateway/templates/akeyless-secure-remote-access/service.yaml
@@ -14,6 +14,9 @@ metadata:
   {{- toYaml .Values.sra.sshConfig.service.annotations | nindent 4 }}
 spec:
   type: {{ required "A valid .Values.sra.sshConfig.service.type entry required!" .Values.sra.sshConfig.service.type }}
+  {{- if .Values.sra.sshConfig.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.sra.sshConfig.service.externalTrafficPolicy }}
+  {{- end }}
   ports:
     - port: {{ .Values.sra.sshConfig.service.port }}
       targetPort: ssh

--- a/charts/akeyless-gateway/templates/akeyless-secure-remote-access/service.yaml
+++ b/charts/akeyless-gateway/templates/akeyless-secure-remote-access/service.yaml
@@ -14,8 +14,11 @@ metadata:
   {{- toYaml .Values.sra.sshConfig.service.annotations | nindent 4 }}
 spec:
   type: {{ required "A valid .Values.sra.sshConfig.service.type entry required!" .Values.sra.sshConfig.service.type }}
-  {{- if .Values.sra.sshConfig.service.externalTrafficPolicy }}
-  externalTrafficPolicy: {{ .Values.sra.sshConfig.service.externalTrafficPolicy }}
+  {{- with .Values.sra.sshConfig.service.externalTrafficPolicy }}
+  {{- if not (or (eq $.Values.sra.sshConfig.service.type "LoadBalancer") (eq $.Values.sra.sshConfig.service.type "NodePort")) }}
+  {{- fail "sra.sshConfig.service.externalTrafficPolicy is only valid when sra.sshConfig.service.type is LoadBalancer or NodePort" }}
+  {{- end }}
+  externalTrafficPolicy: {{ . }}
   {{- end }}
   ports:
     - port: {{ .Values.sra.sshConfig.service.port }}

--- a/charts/akeyless-gateway/values.yaml
+++ b/charts/akeyless-gateway/values.yaml
@@ -601,7 +601,7 @@ sra:
       labels: {}
       type: LoadBalancer
       port: 22
-      externalTrafficPolicy: Cluster
+      externalTrafficPolicy: ""
 
     livenessProbe:
       failureThreshold: 5

--- a/charts/akeyless-gateway/values.yaml
+++ b/charts/akeyless-gateway/values.yaml
@@ -601,6 +601,7 @@ sra:
       labels: {}
       type: LoadBalancer
       port: 22
+      externalTrafficPolicy: Cluster
 
     livenessProbe:
       failureThreshold: 5


### PR DESCRIPTION
## Summary
- Add support for configuring `externalTrafficPolicy` on the SRA SSH `LoadBalancer` service via `.Values.sra.sshConfig.service.externalTrafficPolicy`.
- Field is only rendered when set, so existing installs are unaffected. The default in `values.yaml` is `Cluster`, preserving current behavior.

## Why
Setting `externalTrafficPolicy: Local` on the SRA SSH LoadBalancer is necessary when the source client IP must be preserved (e.g. for audit/allowlisting). Today this requires post-install patching of the Service; this change makes it a first-class chart value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SSH service now supports a configurable external traffic policy.
* **Bug Fixes / Validation**
  * The external traffic policy setting is validated and only accepted when the SSH service type is LoadBalancer or NodePort; invalid combinations are rejected to prevent misconfiguration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akeylesslabs/helm-charts/pull/377?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->