### PR TITLE
ASM-18285 | fix otelcol-metrics-config volumemount

### DIFF
--- a/charts/akeyless-gateway/Chart.yaml
+++ b/charts/akeyless-gateway/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: akeyless-gateway
-version: 2.0.3
+version: 2.0.4
 description: A Helm chart for Kubernetes that deploys akeyless-gateway
 type: application
 keywords:

--- a/charts/akeyless-gateway/templates/deployment.yaml
+++ b/charts/akeyless-gateway/templates/deployment.yaml
@@ -159,7 +159,7 @@ spec:
           {{- if (eq "true" (include "akeyless-gateway.clusterCache.enableTls" . )) }}
             {{ include "akeyless-gateway.clusterCache.tlsVolumeMounts" . | nindent 12 }}
           {{- end }}
-          {{- if and (.Values.globalConfig.metrics.enabled) (.Values.globalConfig.metrics.enabled) }}
+          {{- if and (.Values.globalConfig.metrics.enabled) (.Values.globalConfig.metrics.metricsExistingSecret) }}
             - name: otelcol-metrics-config
               mountPath: /akeyless/otel-config.yaml
               subPath: otel-config.yaml


### PR DESCRIPTION
Two files changed:

- `charts/akeyless-gateway/templates/deployment.yaml` line 162 — replaced the duplicated `(.Values.globalConfig.metrics.enabled)` second predicate with `(.Values.globalConfig.metrics.metricsExistingSecret)` so the `otelcol-metrics-config` `volumeMount` is guarded the same way as the matching volumes entry at line 100.
- `charts/akeyless-gateway/Chart.yaml` — bumped version: `2.0.3 → 2.0.4` (patch bump, matches the pattern of prior small-fix PRs like #315).

Verified with `helm lint` and `helm template` against the chart:

- `globalConfig.metrics.enabled=true` with no secret → neither the `volume` nor the `volumeMount` is rendered (was: `volumeMount` rendered with no matching volume, pod fails to schedule).
- `globalConfig.metrics.enabled=true` + `metricsExistingSecret=gw-metrics-secret` → both `volume` and `volumeMount` render correctly, pointing at the same `Secret`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed OpenTelemetry metrics configuration to properly validate both enabled and secret settings.

* **Chores**
  * Updated Helm chart version to 2.0.4

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akeylesslabs/helm-charts/pull/378?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->