### PR TITLE
ASM-18553 | ztwa fix recording env vars

### DIFF
--- a/charts/akeyless-zero-trust-web-access/Chart.yaml
+++ b/charts/akeyless-zero-trust-web-access/Chart.yaml
@@ -16,7 +16,7 @@ maintainers:
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.3.7
+version: 3.3.8
 appVersion: 2.0.0-rc7
 icon: https://akeylesslabs.github.io/helm-charts/assets/logo/akl.jpeg
 home: https://www.akeyless.io

--- a/charts/akeyless-zero-trust-web-access/Chart.yaml
+++ b/charts/akeyless-zero-trust-web-access/Chart.yaml
@@ -16,7 +16,7 @@ maintainers:
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.3.5
+version: 3.3.6
 appVersion: 2.0.0-rc5
 icon: https://akeylesslabs.github.io/helm-charts/assets/logo/akl.jpeg
 home: https://www.akeyless.io

--- a/charts/akeyless-zero-trust-web-access/Chart.yaml
+++ b/charts/akeyless-zero-trust-web-access/Chart.yaml
@@ -16,7 +16,7 @@ maintainers:
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.3.6
+version: 3.3.7
 appVersion: 2.0.0-rc5
 icon: https://akeylesslabs.github.io/helm-charts/assets/logo/akl.jpeg
 home: https://www.akeyless.io

--- a/charts/akeyless-zero-trust-web-access/templates/dispatcher-deployment.yaml
+++ b/charts/akeyless-zero-trust-web-access/templates/dispatcher-deployment.yaml
@@ -266,6 +266,10 @@ spec:
             - name: RECORDING_UPLOADER_STATE_PATH
               value: {{ $recStatePath | quote }}
             {{- end }}
+{{- if .Values.dispatcher.config.apiGatewayCert.tlsCertsSecretName }}
+            - name: AKEYLESS_CA_BUNDLE
+              value: "/etc/ssl/certs/gw-cert.pem"
+{{- end }}
 {{- if .Values.dispatcher.env }}
           {{- toYaml .Values.dispatcher.env | nindent 12 }}
 {{- end }}

--- a/charts/akeyless-zero-trust-web-access/templates/dispatcher-deployment.yaml
+++ b/charts/akeyless-zero-trust-web-access/templates/dispatcher-deployment.yaml
@@ -254,14 +254,20 @@ spec:
                   name: {{ $recSecretName | quote }}
                   key: {{ $recSecretAccessKeySecretKey | quote }}
 {{- end }}
+            {{- if $recEndpoint }}
             - name: RECORDING_S3_ENDPOINT
               value: {{ $recEndpoint | quote }}
+            {{- end }}
             - name: RECORDING_COMPRESS
               value: {{ ternary "true" "false" $recCompress | quote }}
+            {{- if $recSSEType }}
             - name: RECORDING_SSE_TYPE
               value: {{ $recSSEType | quote }}
+            {{- end }}
+            {{- if $recSSEKmsKey }}
             - name: RECORDING_SSE_KMS_KEY_ID
               value: {{ $recSSEKmsKey | quote }}
+            {{- end }}
             {{- if $recStatePath }}
             - name: RECORDING_UPLOADER_STATE_PATH
               value: {{ $recStatePath | quote }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped Helm chart version to **3.3.8**.
* **Bug Fixes**
  * Improved recording-related environment settings in the dispatcher: the S3 endpoint is now only set when a corresponding value is provided, and SSE settings (type and KMS key id) are only set when their corresponding values are present. Compression behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->