### PR TITLE
ASM-18614-set-sra-ssh-port

### DIFF
--- a/charts/akeyless-gateway/Chart.yaml
+++ b/charts/akeyless-gateway/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: akeyless-gateway
-version: 3.1.1
+version: 3.1.2
 description: A Helm chart for Kubernetes that deploys akeyless-gateway
 maintainers:
   - name: Akeyless

--- a/charts/akeyless-gateway/Chart.yaml
+++ b/charts/akeyless-gateway/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: akeyless-gateway
-version: 3.1.2
+version: 3.1.3
 description: A Helm chart for Kubernetes that deploys akeyless-gateway
 maintainers:
   - name: Akeyless

--- a/charts/akeyless-gateway/templates/akeyless-secure-remote-access/ssh-deployment.yaml
+++ b/charts/akeyless-gateway/templates/akeyless-secure-remote-access/ssh-deployment.yaml
@@ -86,6 +86,8 @@ spec:
           - containerPort: 9900
             name: curl-proxy
           env:
+            - name: SSH_PROXY_PORT
+              value: 2222
             {{- if .Values.cacheHA.enabled }}
             - name: REDIS_SENTINEL_ADDR
               value: {{ include "akeyless-gateway.clusterCache.sentinelAddress" . }}

--- a/charts/akeyless-gateway/templates/akeyless-secure-remote-access/ssh-deployment.yaml
+++ b/charts/akeyless-gateway/templates/akeyless-secure-remote-access/ssh-deployment.yaml
@@ -87,7 +87,7 @@ spec:
             name: curl-proxy
           env:
             - name: SSH_PROXY_PORT
-              value: 2222
+              value: "2222"
             {{- if .Values.cacheHA.enabled }}
             - name: REDIS_SENTINEL_ADDR
               value: {{ include "akeyless-gateway.clusterCache.sentinelAddress" . }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Secure Remote Access SSH gateway settings to set the SSH proxy port to `2222`, matching the container’s SSH port to ensure proper connectivity.
  * Bumped the Helm chart version from `3.1.2` to `3.1.3`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->