### PR TITLE
ASM-17961: SSH bastion needs AppArmor=unconfined for /dev/pts mount

### DIFF
--- a/charts/akeyless-gateway/Chart.yaml
+++ b/charts/akeyless-gateway/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: akeyless-gateway
-version: 3.1.1
+version: 3.1.2
 description: A Helm chart for Kubernetes that deploys akeyless-gateway
 maintainers:
   - name: Akeyless

--- a/charts/akeyless-gateway/templates/_helpers.tpl
+++ b/charts/akeyless-gateway/templates/_helpers.tpl
@@ -710,6 +710,14 @@ securityContext:
 {{- define "akeyless-sra-ssh.containerSecurityContext" -}}
 securityContext:
   allowPrivilegeEscalation: true
+  # The SSH bastion builds a per-session chroot jail and bind-mounts /dev/pts, which needs mount(2).
+  # CAP_SYS_ADMIN authorizes the syscall, but on AppArmor nodes (e.g. Ubuntu) the default container
+  # profile (cri-containerd.apparmor.d / docker-default) silently denies mount regardless of caps.
+  # privileged:true used to grant AppArmor=unconfined implicitly; Phase A must request it explicitly.
+  # No-op on non-AppArmor nodes (e.g. SELinux). Requires k8s >= 1.30; for older clusters use the
+  # container.apparmor.security.beta.kubernetes.io/gateway-sra-ssh: unconfined pod annotation instead.
+  appArmorProfile:
+    type: Unconfined
   {{- include "akeyless-gateway.sshBastionPhaseACaps" . | nindent 2 }}
 {{- end -}}
 

--- a/charts/akeyless-gateway/templates/_helpers.tpl
+++ b/charts/akeyless-gateway/templates/_helpers.tpl
@@ -710,12 +710,10 @@ securityContext:
 {{- define "akeyless-sra-ssh.containerSecurityContext" -}}
 securityContext:
   allowPrivilegeEscalation: true
-  # The SSH bastion builds a per-session chroot jail and bind-mounts /dev/pts, which needs mount(2).
-  # CAP_SYS_ADMIN authorizes the syscall, but on AppArmor nodes (e.g. Ubuntu) the default container
-  # profile (cri-containerd.apparmor.d / docker-default) silently denies mount regardless of caps.
-  # privileged:true used to grant AppArmor=unconfined implicitly; Phase A must request it explicitly.
-  # No-op on non-AppArmor nodes (e.g. SELinux). Requires k8s >= 1.30; for older clusters use the
-  # container.apparmor.security.beta.kubernetes.io/gateway-sra-ssh: unconfined pod annotation instead.
+  # The SSH bastion sets up a per-session chroot jail and bind-mounts /dev/pts, which requires the
+  # mount syscall. On nodes with AppArmor enabled, the default container profile blocks mount even
+  # when CAP_SYS_ADMIN is granted, so the bastion runs AppArmor-unconfined. Requires Kubernetes 1.30+;
+  # on older clusters use the container.apparmor.security.beta.kubernetes.io annotation instead.
   appArmorProfile:
     type: Unconfined
   {{- include "akeyless-gateway.sshBastionPhaseACaps" . | nindent 2 }}

--- a/charts/akeyless-gateway/templates/akeyless-cache/cache.yaml
+++ b/charts/akeyless-gateway/templates/akeyless-cache/cache.yaml
@@ -186,11 +186,10 @@ spec:
                   name: {{ include "akeyless-gateway.clusterCache.secretName" . }}
                   key: cache-pass
           volumeMounts:
-            # /data must be a writable, fsGroup-owned volume so Redis can write its RDB
-            # snapshot. Under strictSecurityPolicy the cache runs rootless (uid 1001) and
-            # the image's /data dir (owned by the image's redis uid) is not writable; with no
-            # volume mounted here bgsave fails with "Permission denied" -> MISCONF/stop-writes
-            # -> liveness probe fails -> CrashLoop. An emptyDir gets chowned to fsGroup 1001.
+            # Redis writes its snapshot to /data. When strictSecurityPolicy runs the cache as a
+            # non-root user, /data must be a mounted volume so fsGroup grants write access — the PVC
+            # when persistence is enabled, otherwise an emptyDir. Without it the snapshot fails and
+            # the pod restarts.
             - name: cache-data
               mountPath: /data
             {{- if (eq "true" (include "akeyless-gateway.clusterCache.enableTls" . )) }}

--- a/charts/akeyless-gateway/templates/akeyless-cache/cache.yaml
+++ b/charts/akeyless-gateway/templates/akeyless-cache/cache.yaml
@@ -185,31 +185,32 @@ spec:
                 secretKeyRef:
                   name: {{ include "akeyless-gateway.clusterCache.secretName" . }}
                   key: cache-pass
-          {{- if or .Values.globalConfig.clusterCache.persistence.enabled (eq "true" (include "akeyless-gateway.clusterCache.enableTls" . )) .Values.globalConfig.clusterCache.extraVolumesMounts }}
           volumeMounts:
-            {{- if .Values.globalConfig.clusterCache.persistence.enabled }}
+            # /data must be a writable, fsGroup-owned volume so Redis can write its RDB
+            # snapshot. Under strictSecurityPolicy the cache runs rootless (uid 1001) and
+            # the image's /data dir (owned by the image's redis uid) is not writable; with no
+            # volume mounted here bgsave fails with "Permission denied" -> MISCONF/stop-writes
+            # -> liveness probe fails -> CrashLoop. An emptyDir gets chowned to fsGroup 1001.
             - name: cache-data
               mountPath: /data
-            {{- end }}
             {{- if (eq "true" (include "akeyless-gateway.clusterCache.enableTls" . )) }}
             {{- include "akeyless-gateway.clusterCache.tlsVolumeMounts" . | nindent 12 -}}
             {{- end }}
             {{- with .Values.globalConfig.clusterCache.extraVolumesMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-          {{- end }}
-      {{- if or .Values.globalConfig.clusterCache.persistence.enabled (eq "true" (include "akeyless-gateway.clusterCache.enableTls" . )) .Values.globalConfig.clusterCache.extraVolumes }}
       volumes:
-        {{- if .Values.globalConfig.clusterCache.persistence.enabled }}
         - name: cache-data
+          {{- if .Values.globalConfig.clusterCache.persistence.enabled }}
           persistentVolumeClaim:
             claimName: {{ .Values.globalConfig.clusterCache.persistence.existingClaim | default (include "akeyless-gateway.clusterCache.pvcName" .) }}
-        {{- end }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
         {{- if (eq "true" (include "akeyless-gateway.clusterCache.enableTls" . )) }}
         {{- include "akeyless-gateway.clusterCache.tlsVolume" . | nindent 6 }}
         {{- end }}
         {{- with .Values.globalConfig.clusterCache.extraVolumes }}
         {{- toYaml . | nindent 6 }}
         {{- end }}
-      {{- end }}
 {{- end }}


### PR DESCRIPTION
Phase A replaced privileged:true with a narrow capability set, but privileged:true also implicitly set the container's AppArmor profile to unconfined. On AppArmor-enforcing nodes (Ubuntu/containerd) the default profile (cri-containerd.apparmor.d / docker-default) silently denies mount(2) regardless of CAP_SYS_ADMIN, so the per-session chroot jail's `mount --bind /dev/pts` fails with exit 32 ("no mount point specified" on the cleanup umount). This was masked during the original validation because it ran on SELinux-permissive Amazon Linux 2023, where containers are effectively unconfined.

Request appArmorProfile: Unconfined explicitly for the SSH bastion container. No-op on non-AppArmor nodes. Uses the k8s >=1.30 field; older clusters need the container.apparmor.security.beta.kubernetes.io/ gateway-sra-ssh: unconfined pod annotation instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Helm chart version to **3.1.2**
* **Security**
  * Improved container security settings for the SSH bastion by explicitly configuring AppArmor behavior to support its jailed/session workflow
* **Bug Fixes**
  * Updated the cache deployment template to always mount `/data`, using **PVC** when persistence is enabled and **emptyDir** otherwise (TLS and extra volumes still only apply when configured)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->