### PR TITLE
ASM-18614: fix SRA SSH proxy port collision (2222 -> 2200)

### DIFF
--- a/charts/akeyless-gateway/Chart.yaml
+++ b/charts/akeyless-gateway/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: akeyless-gateway
-version: 3.1.3
+version: 3.1.4
 description: A Helm chart for Kubernetes that deploys akeyless-gateway
 maintainers:
   - name: Akeyless

--- a/charts/akeyless-gateway/templates/akeyless-secure-remote-access/ssh-deployment.yaml
+++ b/charts/akeyless-gateway/templates/akeyless-secure-remote-access/ssh-deployment.yaml
@@ -81,13 +81,13 @@ spec:
           imagePullPolicy: {{ .Values.sra.image.pullPolicy }}
           {{- include "akeyless-sra-ssh.containerSecurityContext" . | nindent 10 }}
           ports:
-          - containerPort: 2222
+          - containerPort: {{ .Values.sra.sshConfig.proxyPort | default 2200 }}
             name: ssh
           - containerPort: 9900
             name: curl-proxy
           env:
             - name: SSH_PROXY_PORT
-              value: "2222"
+              value: {{ .Values.sra.sshConfig.proxyPort | default 2200 | quote }}
             {{- if .Values.cacheHA.enabled }}
             - name: REDIS_SENTINEL_ADDR
               value: {{ include "akeyless-gateway.clusterCache.sentinelAddress" . }}

--- a/charts/akeyless-gateway/values.yaml
+++ b/charts/akeyless-gateway/values.yaml
@@ -629,7 +629,15 @@ sra:
       annotations: {}
       labels: {}
       type: LoadBalancer
+      ## External port clients connect to (advertised to users via EXTERNAL_SSH_PORT). The Service
+      ## forwards this to the container's named "ssh" port (sshConfig.proxyPort).
       port: 22
+
+    ## TCP port the SSH proxy process binds inside the container; also the Deployment containerPort
+    ## that the Service targets via the named "ssh" port. Must be unprivileged (>1024) because the
+    ## bastion drops CAP_NET_BIND_SERVICE, and must differ from the in-container sshd (2222, the
+    ## proxy's forward target) and the curl-proxy/API (9900). Do not set to 22 or 2222.
+    proxyPort: 2200
 
     livenessProbe:
       failureThreshold: 5


### PR DESCRIPTION
The merged ASM-18614 change set SSH_PROXY_PORT=2222, but the in-container sshd already binds 0.0.0.0:2222 (and is the proxy's forward target, localhost:2222). The Go ssh-proxy and sshd then race for 2222 -> EADDRINUSE, breaking the SSH bastion non-deterministically.

Bind the proxy to a distinct unprivileged port (2200, value-driven via sra.sshConfig.proxyPort) and align the containerPort named "ssh" so the Service's targetPort: ssh routes to the proxy. sshd stays on 2222; clients still connect on service.port (22) via EXTERNAL_SSH_PORT.

Verified with helm template (proxy=2200, sshd=2222, curl=9900) and helm lint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SSH proxy port for Secure Remote Access is now configurable with a default value.

* **Chores**
  * Helm chart version updated to 3.1.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->