### PR TITLE
Add Azure Workload Identity support to akeyless-csi-provider chart

### DIFF
--- a/charts/akeyless-csi-provider/Chart.yaml
+++ b/charts/akeyless-csi-provider/Chart.yaml
@@ -5,7 +5,7 @@ maintainers:
   - name: Akeyless
     email: support@akeyless.io
     url: https://www.akeyless.io
-version: 1.0.3
+version: 1.0.4
 appVersion: 1.0.0
 kubeVersion: ">= 1.14.0-0"
 sources:

--- a/charts/akeyless-csi-provider/README.md
+++ b/charts/akeyless-csi-provider/README.md
@@ -25,3 +25,32 @@ and run `helm install`:
 $ helm repo add akeyless https://akeylesslabs.github.io/helm-charts
 
 ```
+
+## Azure Workload Identity
+
+To authenticate the CSI provider to Akeyless with `azure_ad` (via `akeyless-go-cloud-id`
+`DefaultAzureCredential`), configure AKS Workload Identity on the **provider** DaemonSet.
+The Azure identity is that of the CSI provider pod, not individual application pods.
+
+1. Create a user-assigned managed identity and federated identity credential whose
+   `subject` matches the provider ServiceAccount
+   (`system:serviceaccount:<namespace>:<release>-csi-provider`).
+2. Set Helm values for the provider ServiceAccount annotation and pod label so the
+   AKS Workload Identity webhook injects `AZURE_*` env vars into the provider pods.
+
+```yaml
+csi:
+  serviceAccount:
+    annotations:
+      azure.workload.identity/client-id: "<MI_CLIENT_ID>"
+  pod:
+    labels:
+      azure.workload.identity/use: "true"
+```
+
+In your `SecretProviderClass`, use `akeylessAccessType: azure_ad` and leave
+`akeylessAzureObjectID` unset (empty) so token acquisition uses Workload Identity
+rather than the Azure IMDS endpoint.
+
+See also: [Akeyless CSI Provider](https://github.com/akeylesslabs/akeyless-csi-provider)
+and [Akeyless Azure AD auth method](https://docs.akeyless.io/docs/azure-ad).

--- a/charts/akeyless-csi-provider/templates/_helpers.tpl
+++ b/charts/akeyless-csi-provider/templates/_helpers.tpl
@@ -604,6 +604,20 @@ Sets extra CSI provider pod annotations
 {{- end -}}
 
 {{/*
+Sets extra CSI provider pod labels on the DaemonSet pod template.
+*/}}
+{{- define "csi.pod.labels" -}}
+  {{- if .Values.csi.pod.labels }}
+      {{- $tp := typeOf .Values.csi.pod.labels }}
+      {{- if eq $tp "string" }}
+        {{- tpl .Values.csi.pod.labels . | nindent 8 }}
+      {{- else }}
+        {{- toYaml .Values.csi.pod.labels | nindent 8 }}
+      {{- end }}
+  {{- end }}
+{{- end -}}
+
+{{/*
 Sets extra CSI service account annotations
 */}}
 {{- define "csi.serviceAccount.annotations" -}}

--- a/charts/akeyless-csi-provider/templates/csi-daemonset.yaml
+++ b/charts/akeyless-csi-provider/templates/csi-daemonset.yaml
@@ -9,9 +9,9 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     {{- if .Values.csi.daemonSet.labels }}
-      {{- toYaml .Values.csi.daemonSet.labels | nindent 4 }}
-  {{ template "csi.daemonSet.annotations" . }}
-  {{- end }}
+    {{- toYaml .Values.csi.daemonSet.labels | nindent 4 }}
+    {{- end }}
+  {{- template "csi.daemonSet.annotations" . }}
 spec:
   updateStrategy:
     type: {{ .Values.csi.daemonSet.updateStrategy.type }}
@@ -28,7 +28,8 @@ spec:
       labels:
         app.kubernetes.io/name: {{ template "akeyless.name" . }}-csi-provider
         app.kubernetes.io/instance: {{ .Release.Name }}
-      {{ template "csi.pod.annotations" . }}
+        {{- template "csi.pod.labels" . }}
+      {{- template "csi.pod.annotations" . }}
     spec:
       {{- if .Values.csi.priorityClassName }}
       priorityClassName: {{ .Values.csi.priorityClassName }}

--- a/charts/akeyless-csi-provider/values.schema.json
+++ b/charts/akeyless-csi-provider/values.schema.json
@@ -85,6 +85,12 @@
                                 "string"
                             ]
                         },
+                        "labels": {
+                            "type": [
+                                "object",
+                                "string"
+                            ]
+                        },
                         "tolerations": {
                             "type": [
                                 "null",
@@ -121,6 +127,12 @@
                     "type": "object",
                     "properties": {
                         "annotations": {
+                            "type": [
+                                "object",
+                                "string"
+                            ]
+                        },
+                        "labels": {
                             "type": [
                                 "object",
                                 "string"

--- a/charts/akeyless-csi-provider/values.yaml
+++ b/charts/akeyless-csi-provider/values.yaml
@@ -88,6 +88,16 @@ csi:
     # to the pod.
     annotations: {}
 
+    # Extra labels for the provider pod template (DaemonSet pod). This can either
+    # be YAML or a YAML-formatted multi-line templated string map.
+    #
+    # Required for Azure Workload Identity (and similar OIDC federation webhooks)
+    # so the mutating webhook injects federated token env vars into the provider:
+    #   azure.workload.identity/use: "true"
+    labels: {}
+    # labels:
+    #   azure.workload.identity/use: "true"
+
     # Toleration Settings for provider pods
     # This should be either a multi-line string or YAML matching the Toleration array
     # in a PodSpec.
@@ -100,7 +110,12 @@ csi:
     # Extra annotations for the serviceAccount definition. This can either be
     # YAML or a YAML-formatted multi-line templated string map of the
     # annotations to apply to the serviceAccount.
+    #
+    # For Azure Workload Identity, set the user-assigned managed identity client ID:
+    #   azure.workload.identity/client-id: "<MI_CLIENT_ID>"
     annotations: {}
+    # annotations:
+    #   azure.workload.identity/client-id: "<MI_CLIENT_ID>"
     labels: {}
 
   # Used to configure readinessProbe for the pods.


### PR DESCRIPTION
## Summary
- Add `csi.pod.labels` to the Helm chart so the DaemonSet pod template can receive `azure.workload.identity/use: "true"`, enabling the AKS Workload Identity mutating webhook
- Document and validate `csi.serviceAccount.annotations` for `azure.workload.identity/client-id` mapping (template wiring was already present)
- Fix DaemonSet metadata rendering so `csi.daemonSet.annotations` is applied independently of `csi.daemonSet.labels`
- Bump chart version to `1.0.4` and add README guidance for Azure AD auth via Workload Identity

## Test plan
- [x] `helm template` with default values renders unchanged pod labels
- [x] `helm template` with Azure WI values renders:
  - ServiceAccount annotation `azure.workload.identity/client-id`
  - Pod label `azure.workload.identity/use: "true"`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for configuring custom pod labels on the CSI provider deployment

* **Documentation**
  * Added comprehensive guide for Azure Workload Identity authentication with Akeyless

* **Chores**
  * Updated Helm chart version to 1.0.4

<!-- end of auto-generated comment: release notes by coderabbit.ai -->