### PR TITLE
ASM-18712 | fix hardcoded gw tls cert in sra deployments

### DIFF
--- a/charts/akeyless-gateway/Chart.yaml
+++ b/charts/akeyless-gateway/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: akeyless-gateway
-version: 3.1.4
+version: 3.1.5
 description: A Helm chart for Kubernetes that deploys akeyless-gateway
 maintainers:
   - name: Akeyless

--- a/charts/akeyless-gateway/templates/akeyless-secure-remote-access/deployment.yaml
+++ b/charts/akeyless-gateway/templates/akeyless-secure-remote-access/deployment.yaml
@@ -98,13 +98,6 @@ spec:
             - name: GATEWAY_AUTHORIZED_ACCESS_ID
               value: {{ .Values.globalConfig.authorizedAccessIDs | quote }}
             {{- end }}
-            {{- if .Values.globalConfig.TLSConf.tlsExistingSecret }}
-            - name: AKEYLESS_GW_CERTIFICATE
-              valueFrom:
-                secretKeyRef:
-                  name: {{.Values.globalConfig.TLSConf.tlsExistingSecret | quote  }}
-                  key: {{ (.Values.globalConfig.TLSConf).tlsCertificateSecretKeyName | default "tlsCertificate" }}
-            {{- end }}
             - name: REMOTE_ACCESS_TYPE
               value: "web"
             {{- if .Values.globalConfig.gatewayAuth.azureObjectID }}

--- a/charts/akeyless-gateway/templates/akeyless-secure-remote-access/deployment.yaml
+++ b/charts/akeyless-gateway/templates/akeyless-secure-remote-access/deployment.yaml
@@ -66,7 +66,7 @@ spec:
           secret:
             secretName: {{ .Values.globalConfig.TLSConf.tlsExistingSecret }}
             items:
-              - key: tlsCertificate
+              - key: {{ (.Values.globalConfig.TLSConf).tlsCertificateSecretKeyName | default "tlsCertificate" }}
                 path: gw-cert.pem
         {{- end }}
         {{- if (eq "true" (include "akeyless-gateway.clusterCache.enableTls" . )) }}
@@ -103,7 +103,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{.Values.globalConfig.TLSConf.tlsExistingSecret | quote  }}
-                  key: tlsCertificate
+                  key: {{ (.Values.globalConfig.TLSConf).tlsCertificateSecretKeyName | default "tlsCertificate" }}
             {{- end }}
             - name: REMOTE_ACCESS_TYPE
               value: "web"

--- a/charts/akeyless-gateway/templates/akeyless-secure-remote-access/ssh-deployment.yaml
+++ b/charts/akeyless-gateway/templates/akeyless-secure-remote-access/ssh-deployment.yaml
@@ -65,7 +65,7 @@ spec:
         secret:
           secretName: {{ .Values.globalConfig.TLSConf.tlsExistingSecret }}
           items:
-            - key: tlsCertificate
+            - key: {{ (.Values.globalConfig.TLSConf).tlsCertificateSecretKeyName | default "tlsCertificate" }}
               path: gw-cert.pem
       {{- end }}
       {{- if (eq "true" (include "akeyless-gateway.clusterCache.enableTls" . )) }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Made the TLS certificate secret key name configurable for both secure remote access and SSH deployments, with a default of `tlsCertificate`.
  * This improves compatibility with TLS secrets that use custom key structures.
* **Chores**
  * Bumped the Helm chart version for the gateway from `3.1.4` to `3.1.5`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->