### PR TITLE
Gateway + HTTPRoute + fail-loud guards [2/6]

### DIFF
--- a/charts/akeyless-api-gateway/Chart.yaml
+++ b/charts/akeyless-api-gateway/Chart.yaml
@@ -16,7 +16,7 @@ maintainers:
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.62.15
+version: 1.63.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 4.53.0

--- a/charts/akeyless-api-gateway/templates/_gateway-api.tpl
+++ b/charts/akeyless-api-gateway/templates/_gateway-api.tpl
@@ -1,0 +1,90 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Kubernetes Gateway API helpers + fail-loud guards (ASM-16238).
+
+Every route's backend is THIS chart's own Service. Misuse is made
+unrepresentable at render time by the `validate` guard (G1..G5), which is
+included from templates/gateway-api-validate.yaml so it runs on every render.
+*/}}
+
+{{/* Gateway resource name — defaults to the chart fullname. */}}
+{{- define "akeyless-api-gw.gatewayAPI.gatewayName" -}}
+{{- $gw := (.Values.gatewayAPI).gateway | default dict -}}
+{{- default (include "akeyless-api-gw.fullname" .) $gw.name -}}
+{{- end -}}
+
+{{/* allowedRoutes.namespaces.from for generated listeners (default: Same). */}}
+{{- define "akeyless-api-gw.gatewayAPI.allowedRoutesFrom" -}}
+{{- $gw := (.Values.gatewayAPI).gateway | default dict -}}
+{{- $ar := $gw.allowedRoutes | default dict -}}
+{{- $ns := $ar.namespaces | default dict -}}
+{{- $ns.from | default "Same" -}}
+{{- end -}}
+
+{{/* Comma-joined list of valid service.ports names (for guard messages). */}}
+{{- define "akeyless-api-gw.gatewayAPI.portNames" -}}
+{{- $names := list -}}
+{{- range .Values.service.ports -}}{{- $names = append $names .name -}}{{- end -}}
+{{- $names | join ", " -}}
+{{- end -}}
+
+{{/*
+Resolve a named servicePort to its numeric Service port. Fails loud (G4) when
+the name is not declared in .Values.service.ports.
+  args: dict "port" <name> "root" $
+*/}}
+{{- define "akeyless-api-gw.gatewayAPI.portNumber" -}}
+{{- $name := .port -}}
+{{- $root := .root -}}
+{{- $num := "" -}}
+{{- range $root.Values.service.ports -}}
+{{- if eq .name $name -}}{{- $num = .port -}}{{- end -}}
+{{- end -}}
+{{- if kindIs "string" $num -}}
+{{- fail (printf "akeyless-api-gateway: gatewayAPI route references unknown servicePort %q; valid names: %s" $name (include "akeyless-api-gw.gatewayAPI.portNames" $root)) -}}
+{{- end -}}
+{{- $num -}}
+{{- end -}}
+
+{{/*
+parentRefs block for every route: explicit gatewayAPI.parentRefs when set,
+otherwise the Gateway this chart creates.
+*/}}
+{{- define "akeyless-api-gw.gatewayAPI.parentRefs" -}}
+{{- $ga := .Values.gatewayAPI -}}
+{{- if $ga.parentRefs -}}
+{{- toYaml $ga.parentRefs -}}
+{{- else -}}
+- name: {{ include "akeyless-api-gw.gatewayAPI.gatewayName" . }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Fail-loud guards. Emits NOTHING on success (port lookups are swallowed into a
+throwaway variable); each illegal combination calls `fail`.
+  G1 ingress.enabled AND gatewayAPI.enabled        -> mutually exclusive
+  G2 enabled, gateway.create, no gatewayClassName  -> classname required
+  G3 enabled, gateway.create=false, no parentRefs  -> nothing to attach to
+  G4 any route servicePort not in service.ports    -> (via portNumber)
+*/}}
+{{- define "akeyless-api-gw.gatewayAPI.validate" -}}
+{{- $ga := .Values.gatewayAPI | default dict -}}
+{{- if $ga.enabled -}}
+{{- if .Values.ingress.enabled -}}
+{{- fail "akeyless-api-gateway: ingress.enabled and gatewayAPI.enabled are mutually exclusive — enable exactly one north-south path (Ingress or Gateway API)." -}}
+{{- end -}}
+{{- $gw := $ga.gateway | default dict -}}
+{{- if $gw.create -}}
+{{- if not $gw.gatewayClassName -}}
+{{- fail "akeyless-api-gateway: gatewayAPI.gateway.gatewayClassName is required when gatewayAPI.gateway.create=true (e.g. nginx, cilium, istio, kong, envoy)." -}}
+{{- end -}}
+{{- else -}}
+{{- if not $ga.parentRefs -}}
+{{- fail "akeyless-api-gateway: set gatewayAPI.parentRefs when gatewayAPI.gateway.create=false — there is no Gateway to attach routes to." -}}
+{{- end -}}
+{{- end -}}
+{{- range $ga.httpRoutes -}}{{- $_ := include "akeyless-api-gw.gatewayAPI.portNumber" (dict "port" .servicePort "root" $) -}}{{- end -}}
+{{- range $ga.tlsRoutes -}}{{- $_ := include "akeyless-api-gw.gatewayAPI.portNumber" (dict "port" .servicePort "root" $) -}}{{- end -}}
+{{- range $ga.tcpRoutes -}}{{- $_ := include "akeyless-api-gw.gatewayAPI.portNumber" (dict "port" .servicePort "root" $) -}}{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/akeyless-api-gateway/templates/gateway-api-validate.yaml
+++ b/charts/akeyless-api-gateway/templates/gateway-api-validate.yaml
@@ -1,0 +1,7 @@
+{{- /*
+Render-time validation for the Gateway API surface. Emits no Kubernetes object;
+its only effect is to run the fail-loud guards (G1..G5) on every render so an
+illegal gatewayAPI configuration can never produce a (silently wrong) install.
+Guard unit tests target this template via failedTemplate assertions.
+*/ -}}
+{{- include "akeyless-api-gw.gatewayAPI.validate" . -}}

--- a/charts/akeyless-api-gateway/templates/gateway.yaml
+++ b/charts/akeyless-api-gateway/templates/gateway.yaml
@@ -1,0 +1,31 @@
+{{- $ga := .Values.gatewayAPI | default dict -}}
+{{- if and $ga.enabled (($ga.gateway | default dict).create) -}}
+{{- $gw := $ga.gateway -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ include "akeyless-api-gw.gatewayAPI.gatewayName" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "akeyless-api-gw.labels" . | nindent 4 }}
+  {{- with $gw.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $gw.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  gatewayClassName: {{ required "akeyless-api-gateway: gatewayAPI.gateway.gatewayClassName is required when gatewayAPI.gateway.create=true (e.g. nginx, cilium, istio, kong, envoy)." $gw.gatewayClassName }}
+  listeners:
+  {{- if $gw.listeners }}
+    {{- toYaml $gw.listeners | nindent 4 }}
+  {{- else }}
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: {{ include "akeyless-api-gw.gatewayAPI.allowedRoutesFrom" . }}
+  {{- end }}
+{{- end -}}

--- a/charts/akeyless-api-gateway/templates/httproute.yaml
+++ b/charts/akeyless-api-gateway/templates/httproute.yaml
@@ -1,0 +1,30 @@
+{{- $ga := .Values.gatewayAPI | default dict -}}
+{{- if and $ga.enabled $ga.httpRoutes -}}
+{{- $svc := include "akeyless-api-gw.fullname" . -}}
+{{- $parentRefs := include "akeyless-api-gw.gatewayAPI.parentRefs" . -}}
+{{- range $r := $ga.httpRoutes }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "akeyless-api-gw.fullname" $ }}-{{ $r.servicePort }}
+  namespace: {{ $.Release.Namespace | quote }}
+  labels:
+    {{- include "akeyless-api-gw.labels" $ | nindent 4 }}
+spec:
+  parentRefs:
+    {{- $parentRefs | nindent 4 }}
+  {{- with $r.hostname }}
+  hostnames:
+    - {{ . | quote }}
+  {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: {{ $r.pathType | default $.Values.gatewayAPI.httpRoutePathType | default "PathPrefix" }}
+            value: {{ $r.path | default $.Values.gatewayAPI.httpRoutePath | default "/" }}
+      backendRefs:
+        - name: {{ $svc }}
+          port: {{ include "akeyless-api-gw.gatewayAPI.portNumber" (dict "port" $r.servicePort "root" $) }}
+{{- end }}
+{{- end -}}

--- a/charts/akeyless-api-gateway/templates/service.yaml
+++ b/charts/akeyless-api-gateway/templates/service.yaml
@@ -14,6 +14,8 @@ metadata:
 spec:
   {{- if .Values.ingress.enabled }}
   type: NodePort
+  {{- else if (.Values.gatewayAPI).enabled }}
+  type: ClusterIP
   {{- else }}
   type: {{ required "A valid .Values.service.type entry required!" .Values.service.type }}
   {{- end }}

--- a/charts/akeyless-api-gateway/tests/gateway_api_test.yaml
+++ b/charts/akeyless-api-gateway/tests/gateway_api_test.yaml
@@ -1,0 +1,163 @@
+suite: akeyless-api-gateway Gateway + HTTPRoute (ASM-16238)
+# Render tests for the Gateway API foundation: the Gateway + HTTPRoute resources,
+# the ingress->ClusterIP behaviour switch, and the fail-loud guards G1..G4.
+set:
+  akeylessUserAuth.adminAccessId: p-1234567890
+  # Test-only base64-shaped placeholder; not a real credential.
+  akeylessUserAuth.adminAccessKey: ZHVtbXktYWNjZXNzLWtleQ==
+tests:
+  # ---------- disabled by default ----------
+  - it: renders no Gateway when gatewayAPI is disabled
+    template: templates/gateway.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: renders no HTTPRoute when gatewayAPI is disabled
+    template: templates/httproute.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # ---------- Gateway ----------
+  - it: renders a Gateway (v1) with the chosen GatewayClass and a default http listener
+    template: templates/gateway.yaml
+    set:
+      gatewayAPI.enabled: true
+      gatewayAPI.gateway.gatewayClassName: cilium
+    asserts:
+      - isKind:
+          of: Gateway
+      - isAPIVersion:
+          of: gateway.networking.k8s.io/v1
+      - equal:
+          path: spec.gatewayClassName
+          value: cilium
+      - equal:
+          path: spec.listeners[0].name
+          value: http
+      - equal:
+          path: spec.listeners[0].port
+          value: 80
+      - equal:
+          path: spec.listeners[0].allowedRoutes.namespaces.from
+          value: Same
+  - it: does not render a Gateway in attach mode (gateway.create=false)
+    template: templates/gateway.yaml
+    set:
+      gatewayAPI.enabled: true
+      gatewayAPI.gateway.create: false
+      gatewayAPI.parentRefs:
+        - name: shared-gw
+          namespace: gateway
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # ---------- HTTPRoute ----------
+  - it: renders one HTTPRoute per httpRoutes entry (v1)
+    template: templates/httproute.yaml
+    set:
+      gatewayAPI.enabled: true
+      gatewayAPI.gateway.gatewayClassName: nginx
+    asserts:
+      - hasDocuments:
+          count: 5
+      - isKind:
+          of: HTTPRoute
+      - isAPIVersion:
+          of: gateway.networking.k8s.io/v1
+  - it: maps a named servicePort to the chart Service backend port number
+    template: templates/httproute.yaml
+    set:
+      gatewayAPI.enabled: true
+      gatewayAPI.gateway.gatewayClassName: nginx
+      gatewayAPI.httpRoutes:
+        - hostname: console.example.com
+          servicePort: web
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.hostnames[0]
+          value: console.example.com
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: RELEASE-NAME-akeyless-api-gateway
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 18888
+      - equal:
+          path: spec.parentRefs[0].name
+          value: RELEASE-NAME-akeyless-api-gateway
+      - equal:
+          path: spec.rules[0].matches[0].path.type
+          value: PathPrefix
+  - it: attaches routes to explicit parentRefs (cross-namespace shared Gateway)
+    template: templates/httproute.yaml
+    set:
+      gatewayAPI.enabled: true
+      gatewayAPI.gateway.create: false
+      gatewayAPI.parentRefs:
+        - name: shared-gw
+          namespace: gateway
+      gatewayAPI.httpRoutes:
+        - hostname: api.example.com
+          servicePort: api
+    asserts:
+      - equal:
+          path: spec.parentRefs[0].name
+          value: shared-gw
+      - equal:
+          path: spec.parentRefs[0].namespace
+          value: gateway
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 8081
+
+  # ---------- Service behaviour ----------
+  - it: switches the Service to ClusterIP under Gateway API
+    template: templates/service.yaml
+    set:
+      gatewayAPI.enabled: true
+      gatewayAPI.gateway.gatewayClassName: cilium
+    asserts:
+      - equal:
+          path: spec.type
+          value: ClusterIP
+
+  # ---------- fail-loud guards ----------
+  - it: "G1 — fails when both ingress and gatewayAPI are enabled"
+    template: templates/gateway-api-validate.yaml
+    set:
+      ingress.enabled: true
+      gatewayAPI.enabled: true
+      gatewayAPI.gateway.gatewayClassName: cilium
+    asserts:
+      - failedTemplate:
+          errorMessage: "akeyless-api-gateway: ingress.enabled and gatewayAPI.enabled are mutually exclusive — enable exactly one north-south path (Ingress or Gateway API)."
+  - it: "G2 — fails when gateway.create=true but gatewayClassName is empty"
+    template: templates/gateway.yaml
+    set:
+      gatewayAPI.enabled: true
+      gatewayAPI.gateway.create: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "akeyless-api-gateway: gatewayAPI.gateway.gatewayClassName is required when gatewayAPI.gateway.create=true (e.g. nginx, cilium, istio, kong, envoy)."
+  - it: "G3 — fails when gateway.create=false but parentRefs is empty"
+    template: templates/gateway-api-validate.yaml
+    set:
+      gatewayAPI.enabled: true
+      gatewayAPI.gateway.create: false
+    asserts:
+      - failedTemplate:
+          errorMessage: "akeyless-api-gateway: set gatewayAPI.parentRefs when gatewayAPI.gateway.create=false — there is no Gateway to attach routes to."
+  - it: "G4 — fails when a route references an unknown servicePort"
+    template: templates/httproute.yaml
+    set:
+      gatewayAPI.enabled: true
+      gatewayAPI.gateway.gatewayClassName: cilium
+      gatewayAPI.httpRoutes:
+        - hostname: x.example.com
+          servicePort: nope
+    asserts:
+      - failedTemplate:
+          errorMessage: 'akeyless-api-gateway: gatewayAPI route references unknown servicePort "nope"; valid names: web, configure-app, legacy-api, api, hvp, kmip, grpc'

--- a/charts/akeyless-api-gateway/values.schema.json
+++ b/charts/akeyless-api-gateway/values.schema.json
@@ -69,6 +69,41 @@
         }
       },
       "type": "object"
+    },
+    "gatewayAPI": {
+      "type": "object",
+      "description": "Kubernetes Gateway API support (ASM-16238)",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "gateway": {
+          "type": "object",
+          "properties": {
+            "create": { "type": "boolean" },
+            "name": { "type": "string" },
+            "gatewayClassName": { "type": "string" },
+            "annotations": { "type": "object" },
+            "labels": { "type": "object" },
+            "listeners": { "type": "array" },
+            "allowedRoutes": { "type": "object" }
+          }
+        },
+        "parentRefs": { "type": "array" },
+        "httpRoutes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "hostname": { "type": "string" },
+              "servicePort": { "type": "string" },
+              "path": { "type": "string" },
+              "pathType": { "type": "string", "enum": ["Exact", "PathPrefix", "RegularExpression"] }
+            },
+            "required": ["servicePort"]
+          }
+        },
+        "httpRoutePath": { "type": "string" },
+        "httpRoutePathType": { "type": "string", "enum": ["Exact", "PathPrefix", "RegularExpression"] }
+      }
     }
   },
   "title": "Values",

--- a/charts/akeyless-api-gateway/values.yaml
+++ b/charts/akeyless-api-gateway/values.yaml
@@ -226,6 +226,73 @@ ingress:
 
   ## existingSecret: name-of-existing-secret
 
+## Kubernetes Gateway API support (ASM-16238) — an alternative to `ingress` for
+## clusters whose ingress controller has moved to the Gateway API
+## (NGINX Gateway Fabric, Cilium, Istio, Kong, Envoy Gateway, ...).
+## `ingress` and `gatewayAPI` are MUTUALLY EXCLUSIVE — enabling both fails the
+## render. Every route's backend is this chart's own Service.
+## ref: https://gateway-api.sigs.k8s.io/
+gatewayAPI:
+  ## Set to true to render Gateway API resources instead of an Ingress.
+  enabled: false
+
+  gateway:
+    ## create=true renders a Gateway owned by this release.
+    ## create=false attaches the routes to a pre-existing (shared) Gateway you
+    ## reference via `parentRefs` below.
+    create: true
+
+    ## Gateway name; defaults to the chart fullname when empty.
+    name: ""
+
+    ## REQUIRED when create=true. The GatewayClass selects the controller, e.g.
+    ## nginx (NGINX Gateway Fabric), cilium, istio, kong, envoy-gateway.
+    gatewayClassName: ""
+
+    annotations: {}
+    labels: {}
+
+    ## Listener escape hatch. Leave empty to generate a default `http` listener
+    ## on port 80; HTTPS/TLS listeners are added by the TLS values below.
+    ## Provide a full Gateway-API listener list to take complete control.
+    listeners: []
+
+    ## Which namespaces may attach routes to the generated listener.
+    allowedRoutes:
+      namespaces:
+        from: Same          # Same | All | Selector
+
+  ## parentRefs every route attaches to. Empty => the Gateway created above.
+  ## Point at a Gateway in another namespace to share a cluster Gateway (then
+  ## add a referenceGrant). Example:
+  ##   - name: shared-gateway
+  ##     namespace: gateway
+  ##     sectionName: https
+  parentRefs: []
+
+  ## HTTPRoutes — the same {hostname, servicePort} shape as `ingress.rules`, so
+  ## migrating from Ingress is a near-mechanical rename. `servicePort` must be a
+  ## name from `service.ports` above.
+  httpRoutes:
+    - hostname: "ui.gateway.local"
+      servicePort: web
+    - hostname: "hvp.gateway.local"
+      servicePort: hvp
+    - hostname: "rest.gateway.local"
+      servicePort: legacy-api
+    - hostname: "api.gateway.local"
+      servicePort: api
+    - hostname: "conf.gateway.local"
+      servicePort: configure-app
+    # - hostname: "ui.gateway.local"
+    #   servicePort: web
+    #   path: /custom            # overrides httpRoutePath for this route
+    #   pathType: PathPrefix     # Exact | PathPrefix | RegularExpression
+
+  ## Default path + pathType applied to each generated HTTPRoute rule.
+  httpRoutePath: /
+  httpRoutePathType: PathPrefix
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
Part **[2/6]** of the ** — Kubernetes Gateway API support** stack. Stacked on #392.

Adds Gateway API support to `akeyless-api-gateway` as an **alternative to** `ingress` (the two are **mutually exclusive**). Single-cluster scope — no MCS/ServiceImport/traffic-split (that's the internal saas chart's job).

## New `gatewayAPI` values surface
Ingress-parity authoring — `httpRoutes` use the same `{hostname, servicePort}` shape as `ingress.rules`, so migration is a near-mechanical rename. Every route's backend is the chart's **own Service** on the named port.

```yaml
gatewayAPI:
  enabled: false
  gateway:
    create: true                 # false => attach to a shared Gateway via parentRefs
    gatewayClassName: ""         # required when create=true (nginx|cilium|istio|kong|envoy)
  parentRefs: []
  httpRoutes:
    - { hostname: ui.gateway.local, servicePort: web }
```

## What renders
- `templates/gateway.yaml` → `Gateway` (`gateway.networking.k8s.io/v1`), default `http:80` listener (HTTPS/TLS lands in [3/6])
- `templates/httproute.yaml` → one `HTTPRoute` per `httpRoutes` entry, `backendRef` → the chart Service on the resolved **port number**
- Service switches to `ClusterIP` under Gateway API

## Fail-loud guards (the D18 pattern — misuse unrepresentable at render time)
`templates/_gateway-api.tpl` + `templates/gateway-api-validate.yaml`:
- **G1** `ingress.enabled` + `gatewayAPI.enabled` → mutually exclusive
- **G2** `gateway.create=true` + empty `gatewayClassName` → required
- **G3** `gateway.create=false` + empty `parentRefs` → nothing to attach to
- **G4** route `servicePort` ∉ `service.ports` → lists the valid names

## Render tests
`tests/gateway_api_test.yaml` — **16 cases** (disabled-by-default, Gateway shape, HTTPRoute port mapping, attach-mode parentRefs, ClusterIP switch, and `failedTemplate` assertions for every guard). Run via `nix run ./tools/keyway#keyway-ci`.

Verified locally: `helm unittest` 16/16 ✅, `helm lint` ✅. Chart `1.62.15 → 1.63.0`.


 : https://akeyless.atlassian.net/browse/ ?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
