### PR TITLE
HTTPS/TLS termination + TLSRoute (passthrough) [3/6]

### DIFF
--- a/charts/akeyless-api-gateway/Chart.yaml
+++ b/charts/akeyless-api-gateway/Chart.yaml
@@ -16,7 +16,7 @@ maintainers:
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.63.0
+version: 1.64.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 4.53.0

--- a/charts/akeyless-api-gateway/templates/_gateway-api.tpl
+++ b/charts/akeyless-api-gateway/templates/_gateway-api.tpl
@@ -83,6 +83,12 @@ throwaway variable); each illegal combination calls `fail`.
 {{- fail "akeyless-api-gateway: set gatewayAPI.parentRefs when gatewayAPI.gateway.create=false — there is no Gateway to attach routes to." -}}
 {{- end -}}
 {{- end -}}
+{{- if and $gw.create $ga.tlsRoutes -}}
+{{- $tls := $gw.tls | default dict -}}
+{{- if not (and $tls.enabled (eq ($tls.mode | default "Terminate") "Passthrough")) -}}
+{{- fail "akeyless-api-gateway: gatewayAPI.tlsRoutes require a TLS passthrough listener — set gatewayAPI.gateway.tls.enabled=true and gatewayAPI.gateway.tls.mode=Passthrough (or attach to an external Gateway that provides one)." -}}
+{{- end -}}
+{{- end -}}
 {{- range $ga.httpRoutes -}}{{- $_ := include "akeyless-api-gw.gatewayAPI.portNumber" (dict "port" .servicePort "root" $) -}}{{- end -}}
 {{- range $ga.tlsRoutes -}}{{- $_ := include "akeyless-api-gw.gatewayAPI.portNumber" (dict "port" .servicePort "root" $) -}}{{- end -}}
 {{- range $ga.tcpRoutes -}}{{- $_ := include "akeyless-api-gw.gatewayAPI.portNumber" (dict "port" .servicePort "root" $) -}}{{- end -}}

--- a/charts/akeyless-api-gateway/templates/gateway.yaml
+++ b/charts/akeyless-api-gateway/templates/gateway.yaml
@@ -27,5 +27,29 @@ spec:
       allowedRoutes:
         namespaces:
           from: {{ include "akeyless-api-gw.gatewayAPI.allowedRoutesFrom" . }}
+    {{- $tls := $gw.tls | default dict }}
+    {{- if $tls.enabled }}
+    {{- if eq ($tls.mode | default "Terminate") "Passthrough" }}
+    - name: tls
+      protocol: TLS
+      port: 443
+      tls:
+        mode: Passthrough
+      allowedRoutes:
+        namespaces:
+          from: {{ include "akeyless-api-gw.gatewayAPI.allowedRoutesFrom" . }}
+    {{- else }}
+    - name: https
+      protocol: HTTPS
+      port: 443
+      tls:
+        mode: Terminate
+        certificateRefs:
+          {{- toYaml ($tls.certificateRefs | default list) | nindent 10 }}
+      allowedRoutes:
+        namespaces:
+          from: {{ include "akeyless-api-gw.gatewayAPI.allowedRoutesFrom" . }}
+    {{- end }}
+    {{- end }}
   {{- end }}
 {{- end -}}

--- a/charts/akeyless-api-gateway/templates/tlsroute.yaml
+++ b/charts/akeyless-api-gateway/templates/tlsroute.yaml
@@ -1,0 +1,30 @@
+{{- $ga := .Values.gatewayAPI | default dict -}}
+{{- if and $ga.enabled $ga.tlsRoutes -}}
+{{- $svc := include "akeyless-api-gw.fullname" . -}}
+{{- range $r := $ga.tlsRoutes }}
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: {{ include "akeyless-api-gw.fullname" $ }}-tls-{{ $r.servicePort }}
+  namespace: {{ $.Release.Namespace | quote }}
+  labels:
+    {{- include "akeyless-api-gw.labels" $ | nindent 4 }}
+spec:
+  parentRefs:
+  {{- if $ga.parentRefs }}
+    {{- include "akeyless-api-gw.gatewayAPI.parentRefs" $ | nindent 4 }}
+  {{- else }}
+    - name: {{ include "akeyless-api-gw.gatewayAPI.gatewayName" $ }}
+      sectionName: tls
+  {{- end }}
+  {{- with $r.hostname }}
+  hostnames:
+    - {{ . | quote }}
+  {{- end }}
+  rules:
+    - backendRefs:
+        - name: {{ $svc }}
+          port: {{ include "akeyless-api-gw.gatewayAPI.portNumber" (dict "port" $r.servicePort "root" $) }}
+{{- end }}
+{{- end -}}

--- a/charts/akeyless-api-gateway/tests/gateway_api_tls_test.yaml
+++ b/charts/akeyless-api-gateway/tests/gateway_api_tls_test.yaml
@@ -1,0 +1,99 @@
+suite: akeyless-api-gateway TLS termination + TLSRoute (ASM-16238)
+# Render tests for the 443 listener (Terminate/Passthrough) and TLSRoute, plus
+# guard G5 (tlsRoutes require a passthrough listener).
+set:
+  akeylessUserAuth.adminAccessId: p-1234567890
+  # Test-only base64-shaped placeholder; not a real credential.
+  akeylessUserAuth.adminAccessKey: ZHVtbXktYWNjZXNzLWtleQ==
+  gatewayAPI.enabled: true
+  gatewayAPI.gateway.gatewayClassName: cilium
+tests:
+  - it: adds an https:443 Terminate listener with certificateRefs
+    template: templates/gateway.yaml
+    set:
+      gatewayAPI.gateway.tls.enabled: true
+      gatewayAPI.gateway.tls.mode: Terminate
+      gatewayAPI.gateway.tls.certificateRefs:
+        - name: akeyless-api-tls
+    asserts:
+      - equal:
+          path: spec.listeners[1].name
+          value: https
+      - equal:
+          path: spec.listeners[1].protocol
+          value: HTTPS
+      - equal:
+          path: spec.listeners[1].port
+          value: 443
+      - equal:
+          path: spec.listeners[1].tls.mode
+          value: Terminate
+      - equal:
+          path: spec.listeners[1].tls.certificateRefs[0].name
+          value: akeyless-api-tls
+
+  - it: adds a tls:443 Passthrough listener in passthrough mode
+    template: templates/gateway.yaml
+    set:
+      gatewayAPI.gateway.tls.enabled: true
+      gatewayAPI.gateway.tls.mode: Passthrough
+    asserts:
+      - equal:
+          path: spec.listeners[1].name
+          value: tls
+      - equal:
+          path: spec.listeners[1].protocol
+          value: TLS
+      - equal:
+          path: spec.listeners[1].tls.mode
+          value: Passthrough
+
+  - it: renders only the http listener when tls is disabled
+    template: templates/gateway.yaml
+    asserts:
+      - lengthEqual:
+          path: spec.listeners
+          count: 1
+
+  - it: renders no TLSRoute by default
+    template: templates/tlsroute.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders a TLSRoute (v1alpha2) attached to the tls listener
+    template: templates/tlsroute.yaml
+    set:
+      gatewayAPI.gateway.tls.enabled: true
+      gatewayAPI.gateway.tls.mode: Passthrough
+      gatewayAPI.tlsRoutes:
+        - hostname: secure.example.com
+          servicePort: api
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: TLSRoute
+      - isAPIVersion:
+          of: gateway.networking.k8s.io/v1alpha2
+      - equal:
+          path: spec.hostnames[0]
+          value: secure.example.com
+      - equal:
+          path: spec.parentRefs[0].sectionName
+          value: tls
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: RELEASE-NAME-akeyless-api-gateway
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 8081
+
+  - it: "G5 — tlsRoutes require a passthrough TLS listener"
+    set:
+      gatewayAPI.tlsRoutes:
+        - hostname: secure.example.com
+          servicePort: api
+    asserts:
+      - failedTemplate:
+          errorMessage: "akeyless-api-gateway: gatewayAPI.tlsRoutes require a TLS passthrough listener — set gatewayAPI.gateway.tls.enabled=true and gatewayAPI.gateway.tls.mode=Passthrough (or attach to an external Gateway that provides one)."

--- a/charts/akeyless-api-gateway/values.schema.json
+++ b/charts/akeyless-api-gateway/values.schema.json
@@ -84,7 +84,15 @@
             "annotations": { "type": "object" },
             "labels": { "type": "object" },
             "listeners": { "type": "array" },
-            "allowedRoutes": { "type": "object" }
+            "allowedRoutes": { "type": "object" },
+            "tls": {
+              "type": "object",
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "mode": { "type": "string", "enum": ["Terminate", "Passthrough"] },
+                "certificateRefs": { "type": "array" }
+              }
+            }
           }
         },
         "parentRefs": { "type": "array" },
@@ -102,7 +110,18 @@
           }
         },
         "httpRoutePath": { "type": "string" },
-        "httpRoutePathType": { "type": "string", "enum": ["Exact", "PathPrefix", "RegularExpression"] }
+        "httpRoutePathType": { "type": "string", "enum": ["Exact", "PathPrefix", "RegularExpression"] },
+        "tlsRoutes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "hostname": { "type": "string" },
+              "servicePort": { "type": "string" }
+            },
+            "required": ["servicePort"]
+          }
+        }
       }
     }
   },

--- a/charts/akeyless-api-gateway/values.yaml
+++ b/charts/akeyless-api-gateway/values.yaml
@@ -252,9 +252,21 @@ gatewayAPI:
     annotations: {}
     labels: {}
 
+    ## TLS for the generated 443 listener.
+    ##   mode: Terminate   -> an `https:443` listener; the Gateway terminates TLS
+    ##                        using certificateRefs (HTTPRoutes serve it).
+    ##   mode: Passthrough -> a `tls:443` listener; TLS is forwarded to the
+    ##                        backend by SNI (use gatewayAPI.tlsRoutes below).
+    tls:
+      enabled: false
+      mode: Terminate
+      ## Secret(s) holding the TLS certificate for mode=Terminate, e.g.
+      ##   - name: akeyless-api-tls
+      certificateRefs: []
+
     ## Listener escape hatch. Leave empty to generate a default `http` listener
-    ## on port 80; HTTPS/TLS listeners are added by the TLS values below.
-    ## Provide a full Gateway-API listener list to take complete control.
+    ## on port 80 (plus a 443 listener when tls.enabled above). Provide a full
+    ## Gateway-API listener list to take complete control.
     listeners: []
 
     ## Which namespaces may attach routes to the generated listener.
@@ -292,6 +304,13 @@ gatewayAPI:
   ## Default path + pathType applied to each generated HTTPRoute rule.
   httpRoutePath: /
   httpRoutePathType: PathPrefix
+
+  ## TLSRoutes (SNI passthrough) — used when gatewayAPI.gateway.tls.mode is
+  ## Passthrough. TLS is forwarded to the backend, which terminates it.
+  ## `servicePort` must be a name from `service.ports`.
+  tlsRoutes: []
+    # - hostname: "secure.gateway.local"
+    #   servicePort: api
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
Part **[3/6]** of the ** — Kubernetes Gateway API support** stack. Stacked on #393.

Adds TLS to the Gateway surface — both termination and SNI passthrough.

## 443 listener (driven by `gatewayAPI.gateway.tls`)
```yaml
gateway:
  tls:
    enabled: false
    mode: Terminate              # Terminate | Passthrough
    certificateRefs: []          # [{name: akeyless-api-tls}] for Terminate
```
- `mode: Terminate` → an `https:443` **HTTPS** listener; the Gateway terminates TLS with `certificateRefs` (HTTPRoutes serve it)
- `mode: Passthrough` → a `tls:443` **TLS** listener; TLS is forwarded to the backend by SNI

## TLSRoute (SNI passthrough)
`templates/tlsroute.yaml` → one `TLSRoute` (`gateway.networking.k8s.io/v1alpha2`) per `gatewayAPI.tlsRoutes` entry, attached to the `tls` listener via `sectionName`, `backendRef` → the chart Service on the named port.

> ⚠️ TLSRoute needs the Gateway API **Experimental-channel** CRDs installed in the cluster (documented in [6/6]).

## Guard
- **G5** `tlsRoutes` set without a passthrough listener (`tls.enabled` + `mode: Passthrough`) → fail-loud

## Render tests
`tests/gateway_api_tls_test.yaml` — 6 cases (Terminate listener + certificateRefs, Passthrough listener, no-443-when-disabled, TLSRoute shape/version/sectionName/backend port, and the G5 `failedTemplate`).

Verified locally: `helm unittest` **22/22** across all suites ✅, `helm lint` ✅. Chart `1.63.0 → 1.64.0`.

