### PR TITLE
TCPRoute for KMIP + raw-TCP (SSH) [4/6]

### DIFF
--- a/charts/akeyless-api-gateway/Chart.yaml
+++ b/charts/akeyless-api-gateway/Chart.yaml
@@ -16,7 +16,7 @@ maintainers:
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.64.0
+version: 1.65.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 4.53.0

--- a/charts/akeyless-api-gateway/templates/gateway.yaml
+++ b/charts/akeyless-api-gateway/templates/gateway.yaml
@@ -51,5 +51,13 @@ spec:
           from: {{ include "akeyless-api-gw.gatewayAPI.allowedRoutesFrom" . }}
     {{- end }}
     {{- end }}
+    {{- range $r := $ga.tcpRoutes }}
+    - name: tcp-{{ $r.name }}
+      protocol: TCP
+      port: {{ include "akeyless-api-gw.gatewayAPI.portNumber" (dict "port" $r.servicePort "root" $) }}
+      allowedRoutes:
+        namespaces:
+          from: {{ include "akeyless-api-gw.gatewayAPI.allowedRoutesFrom" $ }}
+    {{- end }}
   {{- end }}
 {{- end -}}

--- a/charts/akeyless-api-gateway/templates/tcproute.yaml
+++ b/charts/akeyless-api-gateway/templates/tcproute.yaml
@@ -1,0 +1,26 @@
+{{- $ga := .Values.gatewayAPI | default dict -}}
+{{- if and $ga.enabled $ga.tcpRoutes -}}
+{{- $svc := include "akeyless-api-gw.fullname" . -}}
+{{- range $r := $ga.tcpRoutes }}
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TCPRoute
+metadata:
+  name: {{ include "akeyless-api-gw.fullname" $ }}-tcp-{{ $r.name }}
+  namespace: {{ $.Release.Namespace | quote }}
+  labels:
+    {{- include "akeyless-api-gw.labels" $ | nindent 4 }}
+spec:
+  parentRefs:
+  {{- if $ga.parentRefs }}
+    {{- include "akeyless-api-gw.gatewayAPI.parentRefs" $ | nindent 4 }}
+  {{- else }}
+    - name: {{ include "akeyless-api-gw.gatewayAPI.gatewayName" $ }}
+      sectionName: tcp-{{ $r.name }}
+  {{- end }}
+  rules:
+    - backendRefs:
+        - name: {{ $svc }}
+          port: {{ include "akeyless-api-gw.gatewayAPI.portNumber" (dict "port" $r.servicePort "root" $) }}
+{{- end }}
+{{- end -}}

--- a/charts/akeyless-api-gateway/tests/gateway_api_tcp_test.yaml
+++ b/charts/akeyless-api-gateway/tests/gateway_api_tcp_test.yaml
@@ -1,0 +1,77 @@
+suite: akeyless-api-gateway TCPRoute (KMIP / raw-TCP) (ASM-16238)
+# Render tests for raw-L4 routing: an auto-generated TCP listener per tcpRoute
+# plus the TCPRoute resource, e.g. KMIP on 5696.
+set:
+  akeylessUserAuth.adminAccessId: p-1234567890
+  # Test-only base64-shaped placeholder; not a real credential.
+  akeylessUserAuth.adminAccessKey: ZHVtbXktYWNjZXNzLWtleQ==
+  gatewayAPI.enabled: true
+  gatewayAPI.gateway.gatewayClassName: cilium
+tests:
+  - it: renders no TCPRoute by default
+    template: templates/tcproute.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: auto-generates a TCP listener per tcpRoute on the service port number
+    template: templates/gateway.yaml
+    set:
+      gatewayAPI.tcpRoutes:
+        - name: kmip
+          servicePort: kmip
+    asserts:
+      - equal:
+          path: spec.listeners[1].name
+          value: tcp-kmip
+      - equal:
+          path: spec.listeners[1].protocol
+          value: TCP
+      - equal:
+          path: spec.listeners[1].port
+          value: 5696
+
+  - it: renders a TCPRoute (v1alpha2) bound to the matching listener + backend port
+    template: templates/tcproute.yaml
+    set:
+      gatewayAPI.tcpRoutes:
+        - name: kmip
+          servicePort: kmip
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: TCPRoute
+      - isAPIVersion:
+          of: gateway.networking.k8s.io/v1alpha2
+      - equal:
+          path: spec.parentRefs[0].sectionName
+          value: tcp-kmip
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: RELEASE-NAME-akeyless-api-gateway
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 5696
+
+  - it: supports multiple tcpRoutes (one TCPRoute + one TCP listener each)
+    template: templates/tcproute.yaml
+    set:
+      gatewayAPI.tcpRoutes:
+        - name: kmip
+          servicePort: kmip
+        - name: grpc-tcp
+          servicePort: grpc
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: "G4 — TCP route with unknown servicePort fails"
+    template: templates/tcproute.yaml
+    set:
+      gatewayAPI.tcpRoutes:
+        - name: bad
+          servicePort: nope
+    asserts:
+      - failedTemplate:
+          errorMessage: 'akeyless-api-gateway: gatewayAPI route references unknown servicePort "nope"; valid names: web, configure-app, legacy-api, api, hvp, kmip, grpc'

--- a/charts/akeyless-api-gateway/values.schema.json
+++ b/charts/akeyless-api-gateway/values.schema.json
@@ -121,6 +121,17 @@
             },
             "required": ["servicePort"]
           }
+        },
+        "tcpRoutes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": { "type": "string" },
+              "servicePort": { "type": "string" }
+            },
+            "required": ["name", "servicePort"]
+          }
         }
       }
     }

--- a/charts/akeyless-api-gateway/values.yaml
+++ b/charts/akeyless-api-gateway/values.yaml
@@ -312,6 +312,14 @@ gatewayAPI:
     # - hostname: "secure.gateway.local"
     #   servicePort: api
 
+  ## TCPRoutes — raw L4 for non-HTTP ports (KMIP 5696, an SSH bastion, etc.).
+  ## Each entry generates a TCP listener on the servicePort's number plus a
+  ## TCPRoute that forwards it to the backend. `name` must be unique;
+  ## `servicePort` must be a name from `service.ports`.
+  tcpRoutes: []
+    # - name: kmip
+    #   servicePort: kmip
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
Part **[4/6]** of the ** — Kubernetes Gateway API support** stack. Stacked on #394.

Adds raw-L4 routing for the non-HTTP ports — **KMIP (5696)** and SSH-bastion-style ports — which cannot ride `HTTPRoute`.

```yaml
gatewayAPI:
  tcpRoutes:
    - name: kmip
      servicePort: kmip      # -> TCP listener on 5696 + TCPRoute -> Service:5696
```

Each `tcpRoutes` entry:
- **auto-generates a `TCP` listener** on the Gateway at the service port's number (named `tcp-<name>`)
- renders a `TCPRoute` (`gateway.networking.k8s.io/v1alpha2`) bound to that listener via `sectionName`, `backendRef` → the chart Service on the named port

> ⚠️ TCPRoute needs the Gateway API **Experimental-channel** CRDs (documented in [6/6]). Raw-TCP support also varies by controller — called out in the Decision Log.

## Render tests
`tests/gateway_api_tcp_test.yaml` — 5 cases (disabled-by-default, auto TCP listener shape, TCPRoute version/sectionName/backend port, multiple tcpRoutes, and the G4 unknown-servicePort `failedTemplate`).

Verified locally: `helm unittest` **27/27** ✅, `helm lint` ✅. Chart `1.64.0 → 1.65.0`.

