### PR TITLE
ReferenceGrant for cross-namespace routing [5/6]

### DIFF
--- a/charts/akeyless-api-gateway/Chart.yaml
+++ b/charts/akeyless-api-gateway/Chart.yaml
@@ -16,7 +16,7 @@ maintainers:
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.65.0
+version: 1.66.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 4.53.0

--- a/charts/akeyless-api-gateway/templates/referencegrant.yaml
+++ b/charts/akeyless-api-gateway/templates/referencegrant.yaml
@@ -1,0 +1,18 @@
+{{- $ga := .Values.gatewayAPI | default dict -}}
+{{- if and $ga.enabled $ga.referenceGrants -}}
+{{- range $g := $ga.referenceGrants }}
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: {{ $g.name }}
+  namespace: {{ $g.namespace | default $.Release.Namespace | quote }}
+  labels:
+    {{- include "akeyless-api-gw.labels" $ | nindent 4 }}
+spec:
+  from:
+    {{- toYaml $g.from | nindent 4 }}
+  to:
+    {{- toYaml $g.to | nindent 4 }}
+{{- end }}
+{{- end -}}

--- a/charts/akeyless-api-gateway/tests/gateway_api_referencegrant_test.yaml
+++ b/charts/akeyless-api-gateway/tests/gateway_api_referencegrant_test.yaml
@@ -1,0 +1,68 @@
+suite: akeyless-api-gateway ReferenceGrant (cross-namespace) (ASM-16238)
+# Render tests for cross-namespace authorization: the ReferenceGrant resource
+# with verbatim from/to and an optional target namespace.
+set:
+  akeylessUserAuth.adminAccessId: p-1234567890
+  # Test-only base64-shaped placeholder; not a real credential.
+  akeylessUserAuth.adminAccessKey: ZHVtbXktYWNjZXNzLWtleQ==
+  gatewayAPI.enabled: true
+  gatewayAPI.gateway.gatewayClassName: cilium
+tests:
+  - it: renders no ReferenceGrant by default
+    template: templates/referencegrant.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders a ReferenceGrant (v1beta1) with verbatim from/to
+    template: templates/referencegrant.yaml
+    set:
+      gatewayAPI.referenceGrants:
+        - name: allow-gw-ns
+          from:
+            - group: gateway.networking.k8s.io
+              kind: HTTPRoute
+              namespace: gateway
+          to:
+            - group: ""
+              kind: Service
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ReferenceGrant
+      - isAPIVersion:
+          of: gateway.networking.k8s.io/v1beta1
+      - equal:
+          path: metadata.name
+          value: allow-gw-ns
+      - equal:
+          path: metadata.namespace
+          value: NAMESPACE
+      - equal:
+          path: spec.from[0].kind
+          value: HTTPRoute
+      - equal:
+          path: spec.from[0].namespace
+          value: gateway
+      - equal:
+          path: spec.to[0].kind
+          value: Service
+
+  - it: places the ReferenceGrant in an explicit target namespace
+    template: templates/referencegrant.yaml
+    set:
+      gatewayAPI.referenceGrants:
+        - name: allow-x
+          namespace: gateway
+          from:
+            - group: gateway.networking.k8s.io
+              kind: HTTPRoute
+              namespace: akeyless
+          to:
+            - group: ""
+              kind: Service
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: gateway

--- a/charts/akeyless-api-gateway/values.schema.json
+++ b/charts/akeyless-api-gateway/values.schema.json
@@ -132,6 +132,19 @@
             },
             "required": ["name", "servicePort"]
           }
+        },
+        "referenceGrants": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": { "type": "string" },
+              "namespace": { "type": "string" },
+              "from": { "type": "array" },
+              "to": { "type": "array" }
+            },
+            "required": ["name", "from", "to"]
+          }
         }
       }
     }

--- a/charts/akeyless-api-gateway/values.yaml
+++ b/charts/akeyless-api-gateway/values.yaml
@@ -320,6 +320,23 @@ gatewayAPI:
     # - name: kmip
     #   servicePort: kmip
 
+  ## ReferenceGrants — authorize cross-namespace references. Gateway API denies
+  ## cross-namespace route<->Gateway and route<->backend references by default;
+  ## a ReferenceGrant in the TARGET namespace is the explicit, auditable grant.
+  ## Use this when a shared Gateway in another namespace routes to this chart's
+  ## Service, or when this chart's routes attach to a Gateway in another
+  ## namespace. Created in the release namespace unless `namespace` is set;
+  ## `from`/`to` are passed through verbatim to the ReferenceGrant spec.
+  referenceGrants: []
+    # - name: allow-shared-gateway-to-akeyless
+    #   from:
+    #     - group: gateway.networking.k8s.io
+    #       kind: HTTPRoute
+    #       namespace: gateway
+    #   to:
+    #     - group: ""
+    #       kind: Service
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
Part **[5/6]** of the ** — Kubernetes Gateway API support** stack. Stacked on #395.

Gateway API denies cross-namespace `route ↔ Gateway` and `route ↔ backend` references by default; a **ReferenceGrant** in the target namespace is the explicit, auditable grant. This is exactly the shape from the ticket's reference example (Vermeer / shared-Gateway scenarios).

```yaml
gatewayAPI:
  referenceGrants:
    - name: allow-shared-gateway-to-akeyless
      # namespace: defaults to the release namespace
      from:
        - { group: gateway.networking.k8s.io, kind: HTTPRoute, namespace: gateway }
      to:
        - { group: "", kind: Service }
```

`templates/referencegrant.yaml` → one `ReferenceGrant` (`gateway.networking.k8s.io/v1beta1`) per entry; `from`/`to` passed through verbatim; created in the release namespace unless `namespace` is set. Schema enforces `required: [name, from, to]`.

## Render tests
`tests/gateway_api_referencegrant_test.yaml` — 3 cases (disabled-by-default, full v1beta1 render with verbatim from/to, explicit target namespace).

Verified locally: `helm unittest` **30/30** across all 5 suites ✅, `helm lint` ✅. Chart `1.65.0 → 1.66.0`.

