### PR TITLE
ZTWA chart: opt-in dual-stack ipFamilyPolicy + IPv6/NAT64 docs

### DIFF
--- a/charts/akeyless-zero-trust-web-access/Chart.yaml
+++ b/charts/akeyless-zero-trust-web-access/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 version: 3.4.0
-appVersion: 2.0.0-rc10
+appVersion: 2.0.0
 icon: https://akeylesslabs.github.io/helm-charts/assets/logo/akl.jpeg
 home: https://www.akeyless.io
 sources:

--- a/charts/akeyless-zero-trust-web-access/Chart.yaml
+++ b/charts/akeyless-zero-trust-web-access/Chart.yaml
@@ -16,7 +16,7 @@ maintainers:
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.3.9
+version: 3.3.10
 appVersion: 2.0.0-rc8
 icon: https://akeylesslabs.github.io/helm-charts/assets/logo/akl.jpeg
 home: https://www.akeyless.io

--- a/charts/akeyless-zero-trust-web-access/templates/NOTES.txt
+++ b/charts/akeyless-zero-trust-web-access/templates/NOTES.txt
@@ -17,3 +17,16 @@ Preferred approach:
 Omitting "image.dockerRepositoryCreds" is fully supported; no action is required if
 you are already using only image pull secrets.
 {{- end }}
+
+Akeyless Zero Trust Web Access — IPv6 / dual-stack
+==================================================
+
+This release supports IPv4, dual-stack, and IPv6-only clusters (e.g. EKS in IPv6 mode).
+
+- IPv6-only clusters require NAT64/DNS64 for pods to reach IPv4-only endpoints
+  (Akeyless Gateway, S3 recording upload, IPv4-only target sites).
+- On dual-stack clusters, set `ipFamilyPolicy: PreferDualStack` (and optionally
+  `ipFamilies`) to expose the Services on both families.
+- Rollback warning: on IPv6-only / IPv6-primary clusters, do NOT roll back to an
+  older ZTWA version — earlier images bind IPv4-only and fail readiness on the IPv6
+  pod IP with no workaround.

--- a/charts/akeyless-zero-trust-web-access/templates/dispatcher-service-discovery.yaml
+++ b/charts/akeyless-zero-trust-web-access/templates/dispatcher-service-discovery.yaml
@@ -8,6 +8,13 @@ metadata:
   annotations:
 {{- toYaml .Values.dispatcher.service.annotations | nindent 4 }}
 spec:
+  {{- with .Values.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   clusterIP: None
   ports:
     - name: http

--- a/charts/akeyless-zero-trust-web-access/templates/dispatcher-service.yaml
+++ b/charts/akeyless-zero-trust-web-access/templates/dispatcher-service.yaml
@@ -12,6 +12,13 @@ metadata:
   annotations:
 {{- toYaml .Values.dispatcher.service.annotations | nindent 4 }}
 spec:
+  {{- with .Values.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- if .Values.dispatcher.ingress.enabled }}
   type: NodePort
 {{- else }}

--- a/charts/akeyless-zero-trust-web-access/templates/web-worker-service.yaml
+++ b/charts/akeyless-zero-trust-web-access/templates/web-worker-service.yaml
@@ -12,6 +12,13 @@ metadata:
   annotations:
 {{- toYaml .Values.webWorker.service.annotations | nindent 4 }}
 spec:
+  {{- with .Values.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   clusterIP: None
   ports:
     - port: {{ .Values.webWorker.service.port }}

--- a/charts/akeyless-zero-trust-web-access/values.yaml
+++ b/charts/akeyless-zero-trust-web-access/values.yaml
@@ -26,6 +26,24 @@ httpProxySettings:
   https_proxy: ""
   no_proxy: ""
 
+# IPv6 / dual-stack.
+# ZTWA runs on IPv4, dual-stack, and IPv6-only clusters (e.g. EKS in IPv6 mode). The
+# images bind dual-stack listeners and resolve workers/dispatcher family-agnostically,
+# so no value is required for IPv6-only clusters.
+#
+# ipFamilyPolicy / ipFamilies are applied to the ZTWA Services only when set. Leave
+# unset to inherit the cluster default (single-stack of the cluster's primary family).
+# On dual-stack clusters, set PreferDualStack to expose Services on both families:
+#   ipFamilyPolicy: PreferDualStack
+#   ipFamilies: [IPv6, IPv4]
+#
+# IPv6-only prerequisite: pods reaching IPv4-only endpoints (Akeyless Gateway, S3 for
+# recording upload, IPv4-only target sites) require NAT64/DNS64 in the cluster (standard
+# on EKS IPv6). The dispatcher Squid egress guard denies cloud metadata over IPv6 and
+# the NAT64 well-known prefix.
+ipFamilyPolicy: ""
+ipFamilies: []
+
 deployment:
   labels: {}
 


### PR DESCRIPTION
## What
Chart-side alignments for ZTWA IPv6 / dual-stack support (app image work: ASM-18665). The images already run on IPv4, dual-stack, and IPv6-only clusters; this makes the chart first-class for those topologies without changing existing behavior.

## Changes
- **Opt-in `ipFamilyPolicy` / `ipFamilies`** values, wired into the dispatcher, discovery, and disc-disp Services. **Default unset → renders nothing → zero change** to existing deployments. Operators set `ipFamilyPolicy: PreferDualStack` on dual-stack clusters to expose both families.
- **Docs** in `values.yaml`: IPv6/dual-stack support + the IPv6-only **NAT64/DNS64 prerequisite**.
- **NOTES.txt** upgrade notification (shown on every install/upgrade): NAT64 prerequisite + **rollback warning** (do not roll ZTWA back below this version on IPv6-only clusters).

## Not changed (already correct on main)
- The older **duplicate `DISPATCHER_DNS`** env is already resolved (distinct `WEB_DISPATCHER_SERVICE_DNS` / `DISPATCHER_DNS`).
- Probes are already **hostless** (`tcpSocket: 9000`, no `host:`) — which is what lets IPv6 probes pass.
- **No image tag bump** here (automated).

## Validation
- `helm lint`: pass.
- Default render: `ipFamilyPolicy` absent on all Services (non-breaking).
- `--set ipFamilyPolicy=PreferDualStack --set ipFamilies={IPv6,IPv4}`: renders on all three Services; valid YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional `ipFamilyPolicy` and `ipFamilies` settings to control IPv4/dual-stack/IPv6-only service behavior.
* **Bug Fixes**
  * Improved service rendering so IP family settings are applied only when explicitly configured.
* **Documentation**
  * Updated in-chart guidance covering IPv6/dual-stack options, NAT64/DNS64 considerations, and rollback notes.
* **Chores**
  * Bumped the Helm chart version to **3.4.0** and updated the app version to **2.0.0**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->