### PR TITLE
ASM-18581: document arm64 support for the unified gateway chart

### DIFF
--- a/charts/akeyless-gateway/README.md
+++ b/charts/akeyless-gateway/README.md
@@ -15,6 +15,33 @@ this README. Please refer to the Kubernetes and Helm documentation.
 
 The Kubernetes [metrics server](https://github.com/kubernetes-sigs/metrics-server) must be configured in your cluster.
 
+### Architecture support (amd64 / arm64)
+
+The Gateway and SRA (`zero-trust-bastion`) images are published as multi-arch
+manifests (`linux/amd64` and `linux/arm64`), so the chart runs on both x86_64 and
+arm64 nodes (e.g. AWS Graviton) with no changes — Kubernetes pulls the image
+variant matching each node's architecture. The chart sets no architecture
+`nodeSelector` by default.
+
+On a **mixed-architecture cluster**, pin the Gateway/SRA workloads to a specific
+node pool via the existing `nodeSelector` fields, for example:
+
+```yaml
+gateway:
+  deployment:
+    nodeSelector:
+      kubernetes.io/arch: arm64
+sra:
+  webConfig:
+    deployment:
+      nodeSelector:
+        kubernetes.io/arch: arm64
+  sshConfig:
+    deployment:
+      nodeSelector:
+        kubernetes.io/arch: arm64
+```
+
 
 ## Add Akeyless Repository
 


### PR DESCRIPTION
## Summary
Part of [ASM-18581](https://akeyless.atlassian.net/browse/ASM-18581) (SRA ARM64). Documentation only — the `akeyless-gateway` chart needs **no template changes** for arm64.

The Gateway and SRA (`zero-trust-bastion`) images are now published as multi-arch manifests, so the chart runs on arm64 nodes (AWS Graviton) unchanged — Kubernetes pulls the per-node arch variant, and the chart sets no architecture `nodeSelector` by default.

- README "Architecture support (amd64 / arm64)" section: multi-arch behavior + a **mixed-cluster** `nodeSelector` example pinning gateway/SRA workloads to an arch-specific node pool.
- The example uses the existing `gateway.deployment.nodeSelector` and `sra.{webConfig,sshConfig}.deployment.nodeSelector` fields (verified present in `values.yaml`).

Scope note: ZTWA (`akeyless-zero-trust-web-access` chart) is a **separate** arm64 effort (not ASM-18581) and is intentionally not touched here.

## Test plan
- [x] `nodeSelector` paths in the example verified against values.yaml
- [ ] Chart lint / CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ASM-18581]: https://akeyless.atlassian.net/browse/ASM-18581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for running the Gateway and SRA on mixed-architecture clusters.
  * Clarified that the images support both amd64 and arm64.
  * Explained how to pin workloads to a specific architecture using existing node selection settings, with an example configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->