### PR TITLE
ASM-18457 Add extra volumes support to gateway chart

### DIFF
--- a/charts/akeyless-gateway/Chart.yaml
+++ b/charts/akeyless-gateway/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: akeyless-gateway
-version: 3.1.4
+version: 3.1.5
 description: A Helm chart for Kubernetes that deploys akeyless-gateway
 maintainers:
   - name: Akeyless

--- a/charts/akeyless-gateway/README.md
+++ b/charts/akeyless-gateway/README.md
@@ -35,6 +35,23 @@ To install the chart run the following:
 helm install gateway akeyless/akeyless-gateway
 ```
 
+## Extra Volumes and Volume Mounts
+
+To add custom Kubernetes volumes to the Gateway pod and mount them into the Gateway container, configure `gateway.deployment.extraVolumes` and `gateway.deployment.extraVolumeMounts`:
+
+```yaml
+gateway:
+  deployment:
+    extraVolumes:
+      - name: custom-secret
+        secret:
+          secretName: custom-secret
+    extraVolumeMounts:
+      - name: custom-secret
+        mountPath: /etc/custom-secret
+        readOnly: true
+```
+
 ## Strict Security Policy (Kyverno/PSA Compliance)
 
 For environments requiring Kyverno or Pod Security Admission (PSA) `restricted` profile compliance, enable the `strictSecurityPolicy` toggle:

--- a/charts/akeyless-gateway/templates/deployment.yaml
+++ b/charts/akeyless-gateway/templates/deployment.yaml
@@ -71,7 +71,7 @@ spec:
         {{- toYaml .Values.gateway.deployment.tolerations | nindent 8 }}
       {{- end }}
       {{- include "akeyless-gateway.imagePullSecrets" . | indent 2 }}
-      {{- if or (.Values.globalConfig.customerFragmentsExistingSecret) (.Values.globalConfig.TLSConf.tlsExistingSecret) (.Values.globalConfig.metrics.enabled) (include "akeyless-gateway.clusterCache.enableTls" .) (eq .Values.gateway.persistence.enabled true) (.Values.gateway.secretsStore.enabled) (.Values.gateway.akeylessConfigVol) }}
+      {{- if or (.Values.globalConfig.customerFragmentsExistingSecret) (.Values.globalConfig.TLSConf.tlsExistingSecret) (.Values.globalConfig.metrics.enabled) (include "akeyless-gateway.clusterCache.enableTls" .) (eq .Values.gateway.persistence.enabled true) (.Values.gateway.secretsStore.enabled) (.Values.gateway.akeylessConfigVol) (.Values.gateway.deployment.extraVolumes) }}
       volumes:
         - name: akeyless-config
           {{- if .Values.gateway.akeylessConfigVol }}
@@ -123,6 +123,9 @@ spec:
           persistentVolumeClaim:
             claimName: {{ .Values.gateway.persistence.existingClaim | default (printf "%s-pvc" (include "akeyless-gateway.fullname" .)) }}
       {{- end }}
+      {{- with .Values.gateway.deployment.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- end }}
       containers:
         - name: {{ include "akeyless-gateway.containerName" . }}
@@ -166,7 +169,7 @@ spec:
               path: /health
               port: 8080
           {{- toYaml .Values.gateway.deployment.readinessProbe | trim | nindent 12 }}
-          {{- if or (.Values.globalConfig.customerFragmentsExistingSecret) (.Values.globalConfig.TLSConf.tlsExistingSecret) (.Values.globalConfig.metrics.enabled) (include "akeyless-gateway.clusterCache.enableTls" .) (eq .Values.gateway.persistence.enabled true) (.Values.gateway.secretsStore.enabled)}}
+          {{- if or (.Values.globalConfig.customerFragmentsExistingSecret) (.Values.globalConfig.TLSConf.tlsExistingSecret) (.Values.globalConfig.metrics.enabled) (include "akeyless-gateway.clusterCache.enableTls" .) (eq .Values.gateway.persistence.enabled true) (.Values.gateway.secretsStore.enabled) (.Values.gateway.akeylessConfigVol) (.Values.gateway.deployment.extraVolumeMounts)}}
           volumeMounts:
             - name: akeyless-config
               mountPath: {{include "akeyless-gateway.root.config.path" $}}/.akeyless
@@ -201,6 +204,9 @@ spec:
           {{- if eq .Values.gateway.persistence.enabled true }}
             - name: persistent-storage
               mountPath: {{ .Values.gateway.persistence.mountPath }}
+          {{- end }}
+          {{- with .Values.gateway.deployment.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- end}}
           resources:

--- a/charts/akeyless-gateway/values.yaml
+++ b/charts/akeyless-gateway/values.yaml
@@ -306,6 +306,18 @@ gateway:
     #  seccompProfile:
     #    type: RuntimeDefault
 
+    ## Extra volumes to add to the Gateway pod.
+    extraVolumes: []
+      # - name: custom-secret
+      #   secret:
+      #     secretName: custom-secret
+
+    ## Extra volume mounts to add to the Gateway container.
+    extraVolumeMounts: []
+      # - name: custom-secret
+      #   mountPath: /etc/custom-secret
+      #   readOnly: true
+
     livenessProbe:
       initialDelaySeconds: 60
       periodSeconds: 30


### PR DESCRIPTION
Add extra Volumes and volume mounts to the `akeyless-gateway` chart

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring extra volumes and volume mounts for the Gateway deployment.
  * Included example settings to help you attach additional Kubernetes storage to the pod.

* **Documentation**
  * Expanded the chart README with guidance and a sample configuration for custom volumes and mounts.

* **Chores**
  * Updated the Helm chart version to `3.1.5`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->