### PR TITLE
ASM-19002 fix cache.yaml volumes indentation with TLS/extraVolumes

### DIFF
--- a/charts/akeyless-gateway/Chart.yaml
+++ b/charts/akeyless-gateway/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: akeyless-gateway
-version: 3.1.5
+version: 3.1.6
 description: A Helm chart for Kubernetes that deploys akeyless-gateway
 maintainers:
   - name: Akeyless

--- a/charts/akeyless-gateway/Chart.yaml
+++ b/charts/akeyless-gateway/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: akeyless-gateway
-version: 3.1.8
+version: 3.1.9
 description: A Helm chart for Kubernetes that deploys akeyless-gateway
 maintainers:
   - name: Akeyless

--- a/charts/akeyless-gateway/ci/cluster-cache-extra-volumes-values.yaml
+++ b/charts/akeyless-gateway/ci/cluster-cache-extra-volumes-values.yaml
@@ -1,0 +1,25 @@
+# Regression test for the extraVolumes variant of ASM-19002.
+# When persistence is enabled the cache-data item sits at 8 spaces in the
+# Deployment volumes list. extraVolumes was injected with `nindent 6`, so any
+# combination of persistence (or TLS) with extraVolumes produced two list items
+# at mismatched indentation and a "did not find expected key" YAML error.
+globalConfig:
+  gatewayAuth:
+    gatewayAccessType: access_key
+    gatewayCredentialsExistingSecret: akeyless-auth
+  clusterCache:
+    enabled: true
+    persistence:
+      enabled: true
+    extraVolumes:
+      - name: extra-cache-vol
+        emptyDir: {}
+
+gateway:
+  service:
+    type: ClusterIP
+
+sra:
+  sshConfig:
+    service:
+      type: ClusterIP

--- a/charts/akeyless-gateway/ci/cluster-cache-tls-values.yaml
+++ b/charts/akeyless-gateway/ci/cluster-cache-tls-values.yaml
@@ -1,0 +1,23 @@
+# Regression test for ASM-19002.
+# Standalone cluster cache with TLS enabled *and* persistence enabled renders
+# two items in the Deployment volumes list. Before the fix the tlsVolume helper
+# was injected with `nindent 6` while the cache-data item sat at 8 spaces,
+# producing mismatched indentation and a "did not find expected key" YAML error.
+globalConfig:
+  gatewayAuth:
+    gatewayAccessType: access_key
+    gatewayCredentialsExistingSecret: akeyless-auth
+  clusterCache:
+    enabled: true
+    enableTls: true
+    persistence:
+      enabled: true
+
+gateway:
+  service:
+    type: ClusterIP
+
+sra:
+  sshConfig:
+    service:
+      type: ClusterIP

--- a/charts/akeyless-gateway/templates/akeyless-cache/cache.yaml
+++ b/charts/akeyless-gateway/templates/akeyless-cache/cache.yaml
@@ -207,9 +207,9 @@ spec:
           emptyDir: {}
           {{- end }}
         {{- if (eq "true" (include "akeyless-gateway.clusterCache.enableTls" . )) }}
-        {{- include "akeyless-gateway.clusterCache.tlsVolume" . | nindent 6 }}
+        {{- include "akeyless-gateway.clusterCache.tlsVolume" . | nindent 8 }}
         {{- end }}
         {{- with .Values.globalConfig.clusterCache.extraVolumes }}
-        {{- toYaml . | nindent 6 }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
 {{- end }}


### PR DESCRIPTION
## Summary
Fixes the bug where the `akeyless-gateway` chart fails to render the standalone cluster-cache `Deployment` with `error converting YAML to JSON: yaml: did not find expected key` whenever `globalConfig.clusterCache.enableTls: true` (or `extraVolumes`) is set.

In the `volumes:` block the `cache-data` volume renders as a list item at **8 spaces**, but the `tlsVolume` helper and `extraVolumes` were injected with `nindent 6`. Two sequence items under `volumes:` at mismatched indentation is invalid YAML, so `helm template`, `helm upgrade`, and Terraform `helm_release` all fail.

## Fix
`templates/akeyless-cache/cache.yaml` — align both includes to `nindent 8` to match the `cache-data` item.

## Regression origin
The `nindent 6` on the TLS/extra volumes is long-standing but was **harmless** while `cache-data` was gated behind `persistence.enabled` (default `false`) — the TLS volume was then the only item under `volumes:`, and a lone sequence item at its parent-key indent is valid YAML.

The break was introduced in `9810071` (#388), shipped as chart `3.1.2`, which made `cache-data` render **unconditionally** (PVC when persistence is enabled, else `emptyDir`) so non-root pods under `strictSecurityPolicy` can write `/data`. From `3.1.2` on, `cache-data` is always an 8-space item and collides with the `nindent 6` items — so `enableTls: true` alone now triggers the error. Broken since `3.1.2`, last-good `3.1.1`.

## Tests
Added two `ci/` regression values files (picked up automatically by `ct lint`/`ct install`):
- `ci/cluster-cache-tls-values.yaml` — persistence + TLS
- `ci/cluster-cache-extra-volumes-values.yaml` — persistence + extraVolumes

Both reproduce the parse error before the fix and pass after; verified locally with `ct lint`.

## Blast radius
Only two shipped template lines change. Rendering a matrix (default / TLS / TLS+persistence / extraVolumes) before vs after shows non-TLS output is structurally identical, and the previously-failing TLS/extraVolumes cases now render valid YAML. Chart version bumped `3.1.5` → `3.1.6`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed YAML parsing errors when enabling cluster cache with both persistence and TLS configuration
  * Fixed YAML parsing errors when using cluster cache with extra volumes

* **Chores**
  * Updated the Helm chart version to **3.1.9**
<!-- end of auto-generated comment: release notes by coderabbit.ai -->