### PR TITLE
ASM-19040 | Only create gateway internal service when SRA is enabled

### DIFF
--- a/charts/akeyless-gateway/Chart.yaml
+++ b/charts/akeyless-gateway/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: akeyless-gateway
-version: 3.1.5
+version: 3.1.6
 description: A Helm chart for Kubernetes that deploys akeyless-gateway
 maintainers:
   - name: Akeyless

--- a/charts/akeyless-gateway/templates/svc.yaml
+++ b/charts/akeyless-gateway/templates/svc.yaml
@@ -37,6 +37,7 @@ spec:
 
   selector:
     {{- include "akeyless-gateway.selectorLabels" . | nindent 4 }}
+{{- if .Values.sra.enabled }}
 ---
 apiVersion: v1
 kind: Service
@@ -55,3 +56,4 @@ spec:
 
   selector:
     {{- include "akeyless-gateway.selectorLabels" . | nindent 4 }}
+{{- end }}


### PR DESCRIPTION
## Summary
- The `akeyless-gateway-internal` ClusterIP service (port 8080, `internal-gw-api`) is consumed **only** by the SRA bastion pods (SSH + web) via the `INTERNAL_GATEWAY_API` env var. The gateway itself talks to `localhost:8080`, not this service.
- It was rendered unconditionally in `svc.yaml`, so an unused service was created whenever `sra.enabled=false`.
- Guard the `-internal` service behind `{{- if .Values.sra.enabled }}`, matching the SRA `service.yaml` pattern (which already gates the `ssh-*-internal` / `web-*` services).
- Bump `akeyless-gateway` chart version `3.1.5` -> `3.1.6`.

No behavior change when SRA is enabled.

## Test plan
- [x] `helm template` with `sra.enabled=false` -> no `-internal` service rendered
- [x] `helm template` with `sra.enabled=true` -> `<release>-akeyless-gateway-internal` service rendered as before


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Internal gateway service is now automatically provisioned when SRA is enabled.

* **Chores**
  * Updated the Akeyless Gateway Helm chart version to 3.1.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->