### PR TITLE
ASM-18714 | gate legacy SRA chart out of bot auto-release by default

### DIFF
--- a/.github/scripts/common.sh
+++ b/.github/scripts/common.sh
@@ -15,16 +15,10 @@ function die() {
   exit 1
 }
 
-# Map a released service to the charts whose versions should be bumped.
-# The legacy standalone SRA chart (akeyless-secure-remote-access) is gated behind
-# release_legacy_sra and is only included when that flag is exactly "true". By default
-# it is skipped so the bot never auto-releases it (ASM-18714): the legacy chart lacks the
-# SSH-bastion securityContext contract of the unified akeyless-gateway chart and re-breaks
-# whenever a hardened non-root image is auto-bumped in. Cut a legacy release deliberately
-# via a reviewed chart PR, or by setting the RELEASE_LEGACY_SRA repo variable to "true".
-#
-# Args:  $1 = service name, $2 = release_legacy_sra ("true" to include the legacy SRA chart)
-# Sets global: selected_charts (array; may be empty for a legacy-only service when gated off)
+# Maps a released service ($1) to the charts to bump, into the selected_charts global.
+# The legacy akeyless-secure-remote-access chart is included only when $2 is exactly
+# "true": it lacks the unified chart's securityContext contract, so auto-bumping
+# hardened non-root images breaks it. Opt in via the RELEASE_LEGACY_SRA repo variable.
 function select_charts_for_service() {
   local service="$1"
   local release_legacy_sra="$2"

--- a/.github/scripts/common.sh
+++ b/.github/scripts/common.sh
@@ -15,6 +15,48 @@ function die() {
   exit 1
 }
 
+# Map a released service to the charts whose versions should be bumped.
+# The legacy standalone SRA chart (akeyless-secure-remote-access) is gated behind
+# release_legacy_sra and is only included when that flag is exactly "true". By default
+# it is skipped so the bot never auto-releases it (ASM-18714): the legacy chart lacks the
+# SSH-bastion securityContext contract of the unified akeyless-gateway chart and re-breaks
+# whenever a hardened non-root image is auto-bumped in. Cut a legacy release deliberately
+# via a reviewed chart PR, or by setting the RELEASE_LEGACY_SRA repo variable to "true".
+#
+# Args:  $1 = service name, $2 = release_legacy_sra ("true" to include the legacy SRA chart)
+# Sets global: selected_charts (array; may be empty for a legacy-only service when gated off)
+function select_charts_for_service() {
+  local service="$1"
+  local release_legacy_sra="$2"
+  selected_charts=()
+
+  case "${service}" in
+    gateway)
+      selected_charts+=("akeyless-api-gateway" "akeyless-gateway")
+      ;;
+    zero-trust-bastion)
+      selected_charts+=("akeyless-gateway")
+      if [[ "${release_legacy_sra}" == "true" ]]; then
+        selected_charts+=("akeyless-secure-remote-access")
+      fi
+      ;;
+    zt-portal)
+      if [[ "${release_legacy_sra}" == "true" ]]; then
+        selected_charts+=("akeyless-secure-remote-access")
+      fi
+      ;;
+    zero-trust-web-access)
+      selected_charts+=("akeyless-zero-trust-web-access")
+      ;;
+    k8s-webhook)
+      selected_charts+=("akeyless-k8s-secrets-injection")
+      ;;
+    *)
+      die "Bad service name"
+      ;;
+  esac
+}
+
 function bump_version() {
   current_version=$1
   bump_target=$2

--- a/.github/scripts/latest_version_release.sh
+++ b/.github/scripts/latest_version_release.sh
@@ -35,10 +35,12 @@ select_charts_for_service "${service}" "${release_legacy_sra}"
 charts=("${selected_charts[@]}")
 
 if [[ ${#charts[@]} -eq 0 ]]; then
-  echo "No charts to release for service '${service}' (RELEASE_LEGACY_SRA=${release_legacy_sra}); the legacy SRA chart is gated off by default — skipping auto-release."
-else
-  echo "Charts to release for service '${service}' (RELEASE_LEGACY_SRA=${release_legacy_sra}): ${charts[*]}"
+  echo "No charts to release for service '${service}' (RELEASE_LEGACY_SRA=${release_legacy_sra}), the legacy SRA chart is gated off by default, skipping auto-release."
+  echo "released=false" >> "${GITHUB_OUTPUT}"
+  exit 0
 fi
+
+echo "Charts to release for service '${service}' (RELEASE_LEGACY_SRA=${release_legacy_sra}): ${charts[*]}"
 
 updated_charts_summary=()
 for chart in "${charts[@]}"; do
@@ -107,6 +109,7 @@ for chart in "${charts[@]}"; do
   popd
 done
 
+echo "released=true" >> "${GITHUB_OUTPUT}"
 echo "new_chart_version=$new_chart_version" >> "${GITHUB_ENV}"
 echo "new_chart_version=$new_chart_version" >> "${GITHUB_OUTPUT}"
 echo "charts=${charts[*]}" >> "${GITHUB_ENV}"

--- a/.github/scripts/latest_version_release.sh
+++ b/.github/scripts/latest_version_release.sh
@@ -24,10 +24,12 @@ if [[ -z "${app_version}" ]]; then
   die "Required environment variable 'app_version' is not set"
 fi
 
-# Release gate for the legacy standalone SRA chart (ASM-18714). Default "false" so the bot
-# never auto-releases akeyless-secure-remote-access; set the RELEASE_LEGACY_SRA repo variable
-# to "true" to opt a legacy release in. See select_charts_for_service in common.sh.
-release_legacy_sra=$(echo "${RELEASE_LEGACY_SRA:-false}" | tr '[:upper:]' '[:lower:]')
+# Release gate for the legacy standalone SRA chart (ASM-18714). Read from the deployment
+# payload (release_legacy_sra), set by the triggering release workflow (e.g. the
+# zero-trust-bastion "Release Legacy SRA" input). Missing/empty -> "false", so the bot never
+# auto-releases akeyless-secure-remote-access unless the trigger explicitly opts in.
+release_legacy_sra=$(echo "$GITHUB_CONTEXT" | jq -r '.payload.release_legacy_sra | select (.!=null)')
+release_legacy_sra=$(echo "${release_legacy_sra:-false}" | tr '[:upper:]' '[:lower:]')
 
 select_charts_for_service "${service}" "${release_legacy_sra}"
 charts=("${selected_charts[@]}")

--- a/.github/scripts/latest_version_release.sh
+++ b/.github/scripts/latest_version_release.sh
@@ -24,10 +24,10 @@ if [[ -z "${app_version}" ]]; then
   die "Required environment variable 'app_version' is not set"
 fi
 
-# Release gate for the legacy standalone SRA chart (ASM-18714). Read from the deployment
-# payload (release_legacy_sra), set by the triggering release workflow (e.g. the
-# zero-trust-bastion "Release Legacy SRA" input). Missing/empty -> "false", so the bot never
-# auto-releases akeyless-secure-remote-access unless the trigger explicitly opts in.
+# Release gate for the legacy standalone SRA chart. Read from the deployment payload
+# (release_legacy_sra), set by the triggering release workflow (e.g. the zero-trust-bastion
+# "Release Legacy SRA" input). Missing/empty -> "false", so the bot never auto-releases
+# akeyless-secure-remote-access unless the trigger explicitly opts in.
 release_legacy_sra=$(echo "$GITHUB_CONTEXT" | jq -r '.payload.release_legacy_sra | select (.!=null)')
 release_legacy_sra=$(echo "${release_legacy_sra:-false}" | tr '[:upper:]' '[:lower:]')
 

--- a/.github/scripts/latest_version_release.sh
+++ b/.github/scripts/latest_version_release.sh
@@ -24,19 +24,18 @@ if [[ -z "${app_version}" ]]; then
   die "Required environment variable 'app_version' is not set"
 fi
 
-charts=()
-if [[ "${service}" == "gateway" ]]; then
-  charts+=("akeyless-api-gateway" "akeyless-gateway")
-elif [[ "${service}" == "zero-trust-bastion" ]]; then
-  charts+=("akeyless-secure-remote-access" "akeyless-gateway")
-elif [[ "${service}" == "zt-portal" ]]; then
- charts+=("akeyless-secure-remote-access")
-elif [[ "${service}" == "zero-trust-web-access" ]]; then
-  charts+=("akeyless-zero-trust-web-access")
-elif [[ "${service}" == "k8s-webhook" ]]; then
-  charts+=("akeyless-k8s-secrets-injection")
+# Release gate for the legacy standalone SRA chart (ASM-18714). Default "false" so the bot
+# never auto-releases akeyless-secure-remote-access; set the RELEASE_LEGACY_SRA repo variable
+# to "true" to opt a legacy release in. See select_charts_for_service in common.sh.
+release_legacy_sra=$(echo "${RELEASE_LEGACY_SRA:-false}" | tr '[:upper:]' '[:lower:]')
+
+select_charts_for_service "${service}" "${release_legacy_sra}"
+charts=("${selected_charts[@]}")
+
+if [[ ${#charts[@]} -eq 0 ]]; then
+  echo "No charts to release for service '${service}' (RELEASE_LEGACY_SRA=${release_legacy_sra}); the legacy SRA chart is gated off by default — skipping auto-release."
 else
-  die "Bad service name"
+  echo "Charts to release for service '${service}' (RELEASE_LEGACY_SRA=${release_legacy_sra}): ${charts[*]}"
 fi
 
 updated_charts_summary=()

--- a/.github/scripts/test_select_charts.sh
+++ b/.github/scripts/test_select_charts.sh
@@ -1,10 +1,8 @@
 #!/usr/bin/env bash
 #
-# Unit tests for select_charts_for_service (ASM-18714 legacy SRA release gate).
-# Verifies that the legacy standalone SRA chart (akeyless-secure-remote-access) is only
-# auto-released when RELEASE_LEGACY_SRA == "true", and that all other services are unaffected.
-#
-# Run locally:  bash .github/scripts/test_select_charts.sh
+# Unit tests for select_charts_for_service: the legacy SRA chart is selected only
+# when release_legacy_sra == "true"; all other services are unaffected.
+# Run:  bash .github/scripts/test_select_charts.sh
 
 dir_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 # shellcheck source=common.sh

--- a/.github/scripts/test_select_charts.sh
+++ b/.github/scripts/test_select_charts.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# Unit tests for select_charts_for_service (ASM-18714 legacy SRA release gate).
+# Verifies that the legacy standalone SRA chart (akeyless-secure-remote-access) is only
+# auto-released when RELEASE_LEGACY_SRA == "true", and that all other services are unaffected.
+#
+# Run locally:  bash .github/scripts/test_select_charts.sh
+
+dir_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+# shellcheck source=common.sh
+source "${dir_path}/common.sh"
+set +e  # common.sh enables `set -e`; the runner drives control flow itself
+
+fail=0
+
+assert_charts() {
+  local desc="$1" service="$2" flag="$3" expected="$4"
+  selected_charts=()
+  select_charts_for_service "${service}" "${flag}"
+  local got="${selected_charts[*]}"
+  if [[ "${got}" == "${expected}" ]]; then
+    echo "ok   - ${desc}"
+  else
+    echo "FAIL - ${desc}: expected [${expected}] got [${got}]"
+    fail=1
+  fi
+}
+
+# --- the gate: legacy SRA chart is opt-in ---
+assert_charts "zero-trust-bastion + flag off skips legacy SRA" \
+  zero-trust-bastion false "akeyless-gateway"
+assert_charts "zero-trust-bastion + flag on includes legacy SRA" \
+  zero-trust-bastion true "akeyless-gateway akeyless-secure-remote-access"
+assert_charts "zt-portal + flag off yields no charts" \
+  zt-portal false ""
+assert_charts "zt-portal + flag on includes legacy SRA" \
+  zt-portal true "akeyless-secure-remote-access"
+
+# --- unrelated services must be unaffected by the gate ---
+assert_charts "gateway service unaffected (flag off)" \
+  gateway false "akeyless-api-gateway akeyless-gateway"
+assert_charts "zero-trust-web-access service unaffected" \
+  zero-trust-web-access false "akeyless-zero-trust-web-access"
+assert_charts "k8s-webhook service unaffected" \
+  k8s-webhook false "akeyless-k8s-secrets-injection"
+
+# --- bad service still fails fast ---
+if ( select_charts_for_service "nonsense" false ) >/dev/null 2>&1; then
+  echo "FAIL - bad service name should exit non-zero"
+  fail=1
+else
+  echo "ok   - bad service name exits non-zero"
+fi
+
+if [[ "${fail}" -eq 0 ]]; then
+  echo "All select_charts_for_service tests passed"
+else
+  echo "select_charts_for_service tests FAILED"
+  exit 1
+fi

--- a/.github/workflows/chart_release.yaml
+++ b/.github/workflows/chart_release.yaml
@@ -66,8 +66,6 @@ jobs:
       - name: Update latest helm chart version
         id: release
         env:
-          # release_legacy_sra rides in this payload (ASM-18714): default false -> the legacy
-          # akeyless-secure-remote-access chart is not auto-released unless the trigger opts in.
           GITHUB_CONTEXT: ${{ toJson(github.event.deployment) }}
         run: .github/scripts/latest_version_release.sh
 

--- a/.github/workflows/chart_release.yaml
+++ b/.github/workflows/chart_release.yaml
@@ -67,6 +67,9 @@ jobs:
         id: release
         env:
           GITHUB_CONTEXT: ${{ toJson(github.event.deployment) }}
+          # Release gate for the legacy standalone SRA chart (ASM-18714). Unset/empty -> "false",
+          # so akeyless-secure-remote-access is never auto-released. Set repo variable to "true" to opt in.
+          RELEASE_LEGACY_SRA: ${{ vars.RELEASE_LEGACY_SRA }}
         run: .github/scripts/latest_version_release.sh
 
       - name: Dispatch manifest update

--- a/.github/workflows/chart_release.yaml
+++ b/.github/workflows/chart_release.yaml
@@ -48,6 +48,7 @@ jobs:
     permissions:
       contents: write
     outputs:
+      released: ${{ steps.release.outputs.released }}
       new_chart_version: ${{ steps.release.outputs.new_chart_version }}
       charts: ${{ steps.release.outputs.charts }}
       updated_charts_summary: ${{ steps.release.outputs.updated_charts_summary }}
@@ -70,6 +71,7 @@ jobs:
         run: .github/scripts/latest_version_release.sh
 
       - name: Dispatch manifest update
+        if: steps.release.outputs.released == 'true'
         uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9
         with:
           github-token: ${{ secrets.AKEYLESS_CI_COMMIT_PUSH_TOKEN }}
@@ -129,12 +131,19 @@ jobs:
       - name: Prepare Slack Message On Success
         id: slack-message-success-creator
         run: |
-          SLACK_MESSAGE="*Service:* $service
-          *Bump version:* $major_minor_patch
-          *App Version:* $app_version
-          *Charts:* $charts
-          *Release summary:* $updated_charts_summary
-          :helm:"
+          if [ -n "$charts" ]; then
+            SLACK_MESSAGE="*Service:* $service
+            *Bump version:* $major_minor_patch
+            *App Version:* $app_version
+            *Charts:* $charts
+            *Release summary:* $updated_charts_summary
+            :helm:"
+          else
+            SLACK_MESSAGE="*Service:* $service
+            *App Version:* $app_version
+            *Charts:* none, legacy SRA release gate is off, nothing was released
+            :no_bell:"
+          fi
           delimiter="$(openssl rand -hex 8)"
           {
             echo "slack-message<<${delimiter}"

--- a/.github/workflows/chart_release.yaml
+++ b/.github/workflows/chart_release.yaml
@@ -66,10 +66,9 @@ jobs:
       - name: Update latest helm chart version
         id: release
         env:
+          # release_legacy_sra rides in this payload (ASM-18714): default false -> the legacy
+          # akeyless-secure-remote-access chart is not auto-released unless the trigger opts in.
           GITHUB_CONTEXT: ${{ toJson(github.event.deployment) }}
-          # Release gate for the legacy standalone SRA chart (ASM-18714). Unset/empty -> "false",
-          # so akeyless-secure-remote-access is never auto-released. Set repo variable to "true" to opt in.
-          RELEASE_LEGACY_SRA: ${{ vars.RELEASE_LEGACY_SRA }}
         run: .github/scripts/latest_version_release.sh
 
       - name: Dispatch manifest update

--- a/.github/workflows/chart_test.yaml
+++ b/.github/workflows/chart_test.yaml
@@ -7,8 +7,23 @@ on:
       - ".github/chart-fixtures/**"
       - ".github/ct.yaml"
       - ".github/workflows/chart_test.yaml"
+      - ".github/scripts/**"
 
 jobs:
+  release-scripts-test:
+    # Unit tests for the release-automation shell logic (e.g. the legacy-SRA release gate,
+    # ASM-18714). Pure bash, no cluster needed.
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Run release-script unit tests
+        run: bash .github/scripts/test_select_charts.sh
+
+
   chart-test:
     # ubuntu-latest currently resolves to ubuntu-24.04, where kind/gateway
     # installs hit a runner-kernel-specific rsyslog permission failure.

--- a/.github/workflows/chart_test.yaml
+++ b/.github/workflows/chart_test.yaml
@@ -11,8 +11,8 @@ on:
 
 jobs:
   release-scripts-test:
-    # Unit tests for the release-automation shell logic (e.g. the legacy-SRA release gate,
-    # ASM-18714). Pure bash, no cluster needed.
+    # Unit tests for the release-automation shell logic (e.g. the legacy-SRA release gate).
+    # Pure bash, no cluster needed.
     runs-on: ubuntu-22.04
     permissions:
       contents: read


### PR DESCRIPTION
ASM-18714 | gate legacy SRA chart out of bot auto-release by default The release bot bumps a service's image into every chart that uses it (latest_version_release.sh), pushing straight to main. For zero-trust-bastion that meant BOTH akeyless-gateway and the legacy standalone akeyless-secure-remote-access chart were auto-released. The legacy chart lacks the SSH-bastion securityContext contract, so a non-root image bump (ztb 3.1.0) auto-shipped a broken chart unreviewed and untested (Chart Test only runs on PRs).
Add a RELEASE_LEGACY_SRA gate (default false) so the bot never auto-releases akeyless-secure-remote-access unless explicitly opted in. Manual chart PRs are unaffected.
- common.sh: extract service->charts mapping into select_charts_for_service; include the legacy SRA chart only when RELEASE_LEGACY_SRA == "true"
- latest_version_release.sh: read the flag (default false), skip legacy when off, handle the now-possible empty selection safely
- chart_release.yaml: pass RELEASE_LEGACY_SRA from the repo variable
- chart_test.yaml: run release-script unit tests on PRs; add .github/scripts/** to the path trigger
- test_select_charts.sh: unit tests for the gate (8 cases) Note: this is a release guardrail only. It does not fix customers who manually upgrade the legacy chart to >=3.1.0 — that still requires the securityContext fix or a freeze-and-migrate decision.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable legacy Secure Remote Access chart selection for supported services.
  * Legacy charts are included only when the legacy release gate is explicitly enabled.

* **Bug Fixes**
  * Release automation now cleanly skips the auto-release flow when no charts are selected.
  * Improved handling for unrecognized service names.

* **Tests**
  * Added unit tests covering chart selection and legacy gating behavior.
  * Release-script validation tests now run on pull requests that update release automation scripts.
  
* **Automation Updates**
  * Dispatch and notifications are now conditioned on whether charts were selected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->