### PR TITLE
removed exstention settings from chrom policy

### DIFF
--- a/charts/akeyless-zero-trust-web-access/README.md
+++ b/charts/akeyless-zero-trust-web-access/README.md
@@ -203,8 +203,8 @@ Existing deployments using `dispatcher.config.recording.*` and `webWorker.config
 
 The web worker runs a Chromium-based browser (`akeyless/zero-trust-web-worker`). Key defaults:
 
-- **Managed policies** — flat Chrome Enterprise JSON in `webWorker.config.policies`, mounted at `/etc/chromium/policies/managed/policies.json`. Operators overriding policies must use the Chrome schema (`URLAllowlist` / `URLBlocklist`, `ExtensionSettings`, etc.), not the legacy Firefox `policies.json` wrapper.
-- **Ephemeral `/config`** — an in-memory `emptyDir` prevents stale Chromium profile and extension cache across pod restarts.
+- **Managed policies** — flat Chrome Enterprise JSON in `webWorker.config.policies`, mounted at `/etc/chromium/policies/managed/policies.json`. Operators overriding policies must use the Chrome schema (`URLAllowlist` / `URLBlocklist`, etc.), not the legacy Firefox `policies.json` wrapper. The sideloaded extension has been removed; navigation and credential injection are driven by the worker agent over CDP, so the policy no longer allowlists an extension ID.
+- **Ephemeral `/config`** — an in-memory `emptyDir` prevents stale Chromium profile data across pod restarts.
 - **`/dev/shm`** — `2Gi` memory-backed `emptyDir` (matches compose `shm_size: 2g`).
 - **`DISPATCHER_DNS`** — set to `<fullname>-dispatcher.<namespace>.svc` (dispatcher Service cluster DNS). Dispatcher pods alias `webWorker.config.dispatcherDNS` (default `rbi.dispatcher`, nginx `server_name`) to `127.0.0.1`.
 - **`CHROMIUM_APP_URL`** — set in the worker image Dockerfile; override via `webWorker.env` only if needed.

--- a/charts/akeyless-zero-trust-web-access/templates/web-worker-deployment.yaml
+++ b/charts/akeyless-zero-trust-web-access/templates/web-worker-deployment.yaml
@@ -235,6 +235,11 @@ spec:
               command:
                 - /var/akeyless/scripts/worker_liveness.sh
 {{- toYaml .Values.webWorker.livenessProbe | trim | nindent 12 }}
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: agent
+{{- toYaml .Values.webWorker.readinessProbe | trim | nindent 12 }}
           lifecycle:
             preStop:
               exec:

--- a/charts/akeyless-zero-trust-web-access/values.yaml
+++ b/charts/akeyless-zero-trust-web-access/values.yaml
@@ -582,12 +582,7 @@ webWorker:
             "http://localhost:12411/*",
             "http://127.0.0.1:12411",
             "http://127.0.0.1:12411/*"
-          ],
-          "ExtensionSettings": {
-            "cdghndnnjccefelakphihcjngdokccpm": {
-              "installation_mode": "allowed"
-            }
-          }
+          ]
         }
 
 dlp:

--- a/charts/akeyless-zero-trust-web-access/values.yaml
+++ b/charts/akeyless-zero-trust-web-access/values.yaml
@@ -512,6 +512,13 @@ webWorker:
     timeoutSeconds: 5
     successThreshold: 1
 
+  readinessProbe:
+    initialDelaySeconds: 5
+    periodSeconds: 5
+    failureThreshold: 6
+    timeoutSeconds: 3
+    successThreshold: 1
+
   env: []
 
   config:
@@ -531,7 +538,7 @@ webWorker:
     # Chromium managed policy format (flat Chrome Enterprise JSON). Override with valid JSON.
     policies: |
         {
-          "DeveloperToolsAvailability": 2,
+          "DeveloperToolsAvailability": 1,
           "PasswordManagerEnabled": false,
           "IncognitoModeAvailability": 1,
           "BrowserSignin": 0,

--- a/docker-compose/akeyless-zero-trust-web-access/docker-compose.yml
+++ b/docker-compose/akeyless-zero-trust-web-access/docker-compose.yml
@@ -88,7 +88,7 @@ services:
       - "10000"
     shm_size: '2gb'
     # Ephemeral /config (tmpfs): jlesage declares VOLUME /config, which otherwise
-    # persists Chromium profile + stale extension SW cache across recreates.
+    # persists stale Chromium profile data across recreates.
     tmpfs:
       - /config:uid=1000,gid=1000,mode=0755
     volumes:

--- a/docker-compose/akeyless-zero-trust-web-access/policies-chrome.json
+++ b/docker-compose/akeyless-zero-trust-web-access/policies-chrome.json
@@ -1,5 +1,5 @@
 {
-  "DeveloperToolsAvailability": 2,
+  "DeveloperToolsAvailability": 1,
   "PasswordManagerEnabled": false,
   "IncognitoModeAvailability": 1,
   "BrowserSignin": 0,

--- a/docker-compose/akeyless-zero-trust-web-access/policies-chrome.json
+++ b/docker-compose/akeyless-zero-trust-web-access/policies-chrome.json
@@ -50,10 +50,5 @@
     "http://localhost:12411/*",
     "http://127.0.0.1:12411",
     "http://127.0.0.1:12411/*"
-  ],
-  "ExtensionSettings": {
-    "cdghndnnjccefelakphihcjngdokccpm": {
-      "installation_mode": "allowed"
-    }
-  }
+  ]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Chromium Worker guidance to align managed policies with the Chrome Enterprise model.
  * Clarified that ephemeral configuration storage prevents stale Chromium profile data across restarts.

* **Configuration**
  * Removed extension-specific allowlisting from managed Chrome policies.
  * Updated developer tools policy settings.
  * Added configurable readiness checks to improve deployment health detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->