### PR TITLE
ASM-19369 | expose SSH keepalive values on the unified gateway chart

### DIFF
--- a/charts/akeyless-gateway/Chart.yaml
+++ b/charts/akeyless-gateway/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: akeyless-gateway
-version: 3.2.1
+version: 3.3.0
 description: A Helm chart for Kubernetes that deploys akeyless-gateway
 maintainers:
   - name: Akeyless
@@ -11,10 +11,10 @@ keywords:
   - akeyless-gateway
   - sra
 icon: https://akeyless-908832575.imgix.net/wp-content/uploads/2024/03/akeyless-2024.png?auto=format%2Ccompress&fm=webp&ixlib=php-3.3.0
-appVersion: 5.0.1_3.2.0
+appVersion: 5.0.1_3.3.0
 annotations:
   gatewayVersion: 5.0.1
-  sraVersion: 3.2.0
+  sraVersion: 3.3.0
 dependencies:
   - name: redis-ha
     version: 4.35.10

--- a/charts/akeyless-gateway/templates/akeyless-secure-remote-access/ssh-deployment.yaml
+++ b/charts/akeyless-gateway/templates/akeyless-secure-remote-access/ssh-deployment.yaml
@@ -110,6 +110,24 @@ spec:
             - name: SSH_HOST_KEYS_PATH
               value: {{ .Values.sra.sshConfig.sshHostKeysPath }}
             {{- end }}
+            {{- with .Values.sra.sshConfig.keepalive }}
+            {{- if kindIs "invalid" .clientAliveInterval | not }}
+            - name: SSH_CLIENT_ALIVE_INTERVAL
+              value: {{ .clientAliveInterval | quote }}
+            {{- end }}
+            {{- if kindIs "invalid" .clientAliveCountMax | not }}
+            - name: SSH_CLIENT_ALIVE_COUNT_MAX
+              value: {{ .clientAliveCountMax | quote }}
+            {{- end }}
+            {{- if kindIs "invalid" .serverAliveInterval | not }}
+            - name: SSH_SERVER_ALIVE_INTERVAL
+              value: {{ .serverAliveInterval | quote }}
+            {{- end }}
+            {{- if kindIs "invalid" .serverAliveCountMax | not }}
+            - name: SSH_SERVER_ALIVE_COUNT_MAX
+              value: {{ .serverAliveCountMax | quote }}
+            {{- end }}
+            {{- end }}
             - name: REMOTE_ACCESS_TYPE
               value: "ssh-proxy"
             - name: VERSION

--- a/charts/akeyless-gateway/values.yaml
+++ b/charts/akeyless-gateway/values.yaml
@@ -651,6 +651,20 @@ sra:
     ## proxy's forward target) and the curl-proxy/API (9900). Do not set to 22 or 2222.
     proxyPort: 2200
 
+    ## SSH keepalive probes, left unset so the sra image keeps deciding the defaults.
+    ## A leg drops once "interval x count max" seconds pass with no reply, so the shipped
+    ## 120 and 2 give a 240 second window. clientAlive covers the client to gateway leg,
+    ## serverAlive the gateway to target leg. Lower them when a firewall, NAT, or load
+    ## balancer reaps idle connections sooner than that, and raise them to keep long idle
+    ## sessions alive at the cost of holding credentials for an abandoned session longer.
+    ## Set an interval to 0 to send no probes on that leg. Changes need a pod restart, and
+    ## a sra image older than the release that added these variables ignores them.
+    keepalive: {}
+      # clientAliveInterval: 120
+      # clientAliveCountMax: 2
+      # serverAliveInterval: 120
+      # serverAliveCountMax: 2
+
     livenessProbe:
       failureThreshold: 5
       periodSeconds: 30


### PR DESCRIPTION
Implements [ASM-19369](https://akeyless.atlassian.net/browse/ASM-19369), the unified-chart half of [ASM-19019](https://akeyless.atlassian.net/browse/ASM-19019).

Surfaces the four SSH keepalive environment variables as first-class values on the SRA ssh-proxy container.

```yaml
sra:
  sshConfig:
    keepalive: {}
      # clientAliveInterval: 120
      # clientAliveCountMax: 2
      # serverAliveInterval: 120
      # serverAliveCountMax: 2
```

The ticket sketched `sshProxy.keepalive.*`, which does not exist in this chart. `sra.sshConfig.keepalive.*` matches the existing structure.

## Defaults ship unset, deliberately

Each env var is emitted only when its value is set, so the bastion image keeps deciding the defaults and an untouched install renders exactly as it did before. Writing 120 and 2 into `values.yaml` would create copies of numbers that already live in the image and its Go config, across two repos, and any drift would silently change behaviour for every customer who never touched the setting. With the keys unset, "unchanged unless you set it" is structural rather than hand-maintained. This matches how `sshHostKeysPath` and `CAPublicKey` are already presented.

The `keepalive: {}` map itself is present on purpose. A missing intermediate map turns `.Values.sra.sshConfig.keepalive.clientAliveInterval` into a nil-pointer render error rather than an empty value.

The presence test is `kindIs "invalid" | not`, not a truthiness check. `0` is a documented setting meaning send no probes, and `{{- if .clientAliveInterval }}` would silently drop exactly that value.

## Version fields

The bastion image ships first as 3.3.0, so the chart carries it:

| Field | From | To |
| --- | --- | --- |
| chart `version` | 3.2.0 | 3.3.0 |
| `appVersion` | 5.0.1_3.2.0 | 5.0.1_3.3.0 |
| `annotations.sraVersion` | 3.2.0 | 3.3.0 |

`gatewayVersion` is untouched. The chart `version` and `sraVersion` both reading 3.3.0 is coincidence, not coupling.

This means a default install now pulls `akeyless/zero-trust-bastion:3.3.0`, an image that honours these variables, so there is no ordering hazard against the app PR. Only an explicitly pinned older `sra.image.tag` would ignore them.

## Verification

- `helm lint` passes, with and without keepalive values set.
- With the keys unset, `helm template` output is byte-identical to the pre-change baseline apart from the intended chart-version labels. No env vars are added.
- With all four set, all four render, including `serverAliveInterval: 0` rendering as `"0"` rather than being dropped.
- A partial set emits only the keys provided.
- Full-chart render parses as valid YAML (12 documents).
- No `values.schema.json` change needed: it constrains only `globalConfig` and sets no `additionalProperties: false`, so `sra.*` is unconstrained.

The keepalive entries precede the `sra.env` and `globalConfig.env` passthroughs, so an explicit user override still wins.

## Notes

- Depends on akeylesslabs/zero-trust-bastion#393, which teaches the image to read these variables. Merge that first.
- Changing these values requires a pod restart, stated in the values comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ASM-19369]: https://akeyless.atlassian.net/browse/ASM-19369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ASM-19019]: https://akeyless.atlassian.net/browse/ASM-19019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable SSH keepalive probes for Secure Remote Access deployments.
  * Added settings for client and server keepalive intervals and maximum probe counts.

* **Enhancements**
  * Updated the Helm chart and Secure Remote Access component version to 3.3.0.
  * Existing gateway version remains 5.0.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->