### PR TITLE
akeyless-gateway: use a neutral gateway class in render fixtures

### DIFF
--- a/charts/akeyless-gateway/Chart.yaml
+++ b/charts/akeyless-gateway/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: akeyless-gateway
-version: 3.2.1
+version: 3.2.2
 description: A Helm chart for Kubernetes that deploys akeyless-gateway
 maintainers:
   - name: Akeyless

--- a/charts/akeyless-gateway/ci/gateway-api-values.yaml
+++ b/charts/akeyless-gateway/ci/gateway-api-values.yaml
@@ -9,7 +9,7 @@ gatewayAPI:
     # No controller runs in the kind cluster, so the Gateway stays
     # unprogrammed. That is fine: helm --wait does not gate on custom
     # resources, and the point here is CRD schema validation on apply.
-    gatewayClassName: cilium
+    gatewayClassName: example-gateway-class
   httpRoutes:
     - hostname: gw.ci.example.com
       servicePort: gateway

--- a/charts/akeyless-gateway/tests/gateway-api-gateway_test.yaml
+++ b/charts/akeyless-gateway/tests/gateway-api-gateway_test.yaml
@@ -2,7 +2,7 @@ suite: akeyless-gateway gatewayAPI Gateway
 set:
   gatewayAPI.enabled: true
   gatewayAPI.gateway.create: true
-  gatewayAPI.gateway.gatewayClassName: cilium
+  gatewayAPI.gateway.gatewayClassName: example-gateway-class
 tests:
   - it: renders a Gateway (v1) named after the gateway Service, default http listener
     template: templates/gateway-api/gateway.yaml
@@ -16,7 +16,7 @@ tests:
           value: RELEASE-NAME-akeyless-gateway
       - equal:
           path: spec.gatewayClassName
-          value: cilium
+          value: example-gateway-class
       - equal:
           path: spec.listeners[0].name
           value: http

--- a/charts/akeyless-gateway/tests/gateway-api-guards_test.yaml
+++ b/charts/akeyless-gateway/tests/gateway-api-guards_test.yaml
@@ -4,7 +4,7 @@ tests:
     set:
       gatewayAPI.enabled: true
       gatewayAPI.gateway.create: true
-      gatewayAPI.gateway.gatewayClassName: cilium
+      gatewayAPI.gateway.gatewayClassName: example-gateway-class
       gateway.ingress.enabled: true
     asserts:
       - failedTemplate:
@@ -41,7 +41,7 @@ tests:
   - it: "G4 — tls.mode=Passthrough requires the Tier 1.5 TLSRoute/TCPRoute overlay, not present in this chart alone"
     set:
       gatewayAPI.enabled: true
-      gatewayAPI.gateway.gatewayClassName: cilium
+      gatewayAPI.gateway.gatewayClassName: example-gateway-class
       gatewayAPI.gateway.create: true
       gatewayAPI.gateway.tls.enabled: true
       gatewayAPI.gateway.tls.certificateRefs:
@@ -56,7 +56,7 @@ tests:
     set:
       gatewayAPI.enabled: true
       gatewayAPI.gateway.create: true
-      gatewayAPI.gateway.gatewayClassName: cilium
+      gatewayAPI.gateway.gatewayClassName: example-gateway-class
       gatewayAPI.httpRoutes:
         - hostname: x.example.com
           servicePort: nope
@@ -67,7 +67,7 @@ tests:
   - it: "G6 — gateway.listeners override with tls.httpsRedirect (no way to know which custom listener to attach the redirect to)"
     set:
       gatewayAPI.enabled: true
-      gatewayAPI.gateway.gatewayClassName: cilium
+      gatewayAPI.gateway.gatewayClassName: example-gateway-class
       gatewayAPI.gateway.create: true
       gatewayAPI.gateway.tls.httpsRedirect: true
       gatewayAPI.gateway.listeners:
@@ -83,7 +83,7 @@ tests:
     set:
       gatewayAPI.enabled: true
       gatewayAPI.gateway.create: true
-      gatewayAPI.gateway.gatewayClassName: cilium
+      gatewayAPI.gateway.gatewayClassName: example-gateway-class
       gatewayAPI.parentRefs:
         - name: shared-gw
           namespace: gateway
@@ -103,7 +103,7 @@ tests:
     set:
       gatewayAPI.enabled: true
       gatewayAPI.gateway.create: true
-      gatewayAPI.gateway.gatewayClassName: cilium
+      gatewayAPI.gateway.gatewayClassName: example-gateway-class
       gatewayAPI.gateway.tls.enabled: true
     asserts:
       - failedTemplate:

--- a/charts/akeyless-gateway/tests/gateway-api-matrix_test.yaml
+++ b/charts/akeyless-gateway/tests/gateway-api-matrix_test.yaml
@@ -2,7 +2,7 @@ suite: akeyless-gateway gatewayAPI matrix
 set:
   gatewayAPI.enabled: true
   gatewayAPI.gateway.create: true
-  gatewayAPI.gateway.gatewayClassName: cilium
+  gatewayAPI.gateway.gatewayClassName: example-gateway-class
   gatewayAPI.gateway.tls.enabled: true
   gatewayAPI.gateway.tls.mode: Terminate
   gatewayAPI.gateway.tls.httpsRedirect: true

--- a/charts/akeyless-gateway/tests/gateway-api-routes_test.yaml
+++ b/charts/akeyless-gateway/tests/gateway-api-routes_test.yaml
@@ -2,7 +2,7 @@ suite: akeyless-gateway gatewayAPI routes
 set:
   gatewayAPI.enabled: true
   gatewayAPI.gateway.create: true
-  gatewayAPI.gateway.gatewayClassName: cilium
+  gatewayAPI.gateway.gatewayClassName: example-gateway-class
 tests:
   - it: HTTPRoute targets the gateway Service on the gateway port (8000)
     template: templates/gateway-api/httproute.yaml


### PR DESCRIPTION
Follow-up to #420. Test and CI fixture rename only.

## What

The Gateway API render fixtures set `gatewayClassName: cilium`, which reads as if the chart targets Cilium. It does not. Replaced with `example-gateway-class` in the four helm-unittest suites and in the `ct install` values.

## Why this is safe

The chart is controller-agnostic:

- `values.yaml` defaults `gatewayAPI.gateway.gatewayClassName` to `""`
- `templates/gateway-api/gateway.yaml` passes the value straight through — `gatewayClassName: {{ required "..." $gw.gatewayClassName }}`
- no template logic branches on any controller name

So the fixture value is arbitrary. **No template and no values file is modified**, and no rendered output changes for any real deployment.

## What deliberately did not change

`templates/gateway-api/gateway.yaml` keeps its required-message listing real controller examples (`cilium, nginx, istio, kong, envoy, aws-alb`). Naming several implementations is what tells an operator hitting that error that the chart works with any of them — a placeholder there would make the message less useful. The guard test asserting that message verbatim is unchanged along with it.

That leaves exactly two `cilium` mentions in the chart, both halves of that one help string.

## Verification

| Check | Result |
|---|---|
| `helm unittest charts/akeyless-gateway` | 4 suites, 25 tests, all pass — same count as before |
| `helm lint charts/akeyless-gateway` | 0 failed (pre-existing unvendored `redis-ha` warning, unrelated) |
| `cilium` as a fixture or config value | none remaining |

Chart version bumped 3.2.1 → 3.2.2, matching #420.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated the Helm chart release to version 3.4.2.
  - Gateway API configurations now use `example-gateway-class` as the GatewayClass name.

- **Bug Fixes**
  - Updated Gateway API validation scenarios to consistently recognize the configured GatewayClass name.

- **Tests**
  - Refreshed Gateway API rendering, guard, matrix, and route checks to reflect the updated configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
