### PR TITLE
expose existingSecret for injector webhook TLS certificates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,8 @@ Service-to-chart mappings in `.github/scripts/latest_version_release.sh`:
 
 ### `akeyless-k8s-secrets-injection`
 
-- `templates/apiservice-webhook.yaml` creates a generated CA/cert Secret and one `MutatingWebhookConfiguration`.
+- `templates/apiservice-webhook.yaml` creates a generated CA/cert Secret and one `MutatingWebhookConfiguration`. Setting `.Values.webhook.tls.existingSecretName` skips the Secret and the `genCA`/`genSignedCert` calls so the render is deterministic for GitOps; `caBundle` then comes from `.Values.webhook.tls.caBundle` or is left to a `caBundleAnnotations` injector.
+- Do not use `lookup` to stabilize the generated certificate. It returns empty during `helm template`, which is exactly how ArgoCD renders, so it would not address the drift it appears to fix.
 - New Kubernetes `MutatingWebhook` fields can generally be passed through `.Values.mutatingWebhook` without changing the template.
 - Use `.Values.mutatingWebhook.failurePolicy` for the webhook failure policy. The old top-level `webhookFailurePolicy` value was removed in chart `2.0.0`.
 - `.Values.mutatingWebhook.namespaceSelector`, `.Values.mutatingWebhook.objectSelector`, and `.Values.mutatingWebhook.matchConditions` are rendered with `tpl`, so defaults and overrides can reference release context.

--- a/charts/akeyless-k8s-secrets-injection/Chart.yaml
+++ b/charts/akeyless-k8s-secrets-injection/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.2.0
+version: 2.3.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.39.0

--- a/charts/akeyless-k8s-secrets-injection/README.md
+++ b/charts/akeyless-k8s-secrets-injection/README.md
@@ -59,6 +59,65 @@ mutatingWebhook:
   failurePolicy: Fail
 ```
 
+### Webhook serving certificate (GitOps / cert-manager)
+
+By default the chart generates a self-signed CA and serving certificate while rendering. That
+generation is non-deterministic, so every `helm template` or `helm upgrade` produces a different
+keypair. GitOps controllers such as ArgoCD render the chart on every sync cycle, so with auto-sync
+and self-heal enabled they continuously detect drift and push a new certificate. This produces
+`tls: bad certificate` handshake errors and rolls the webhook pods on every sync.
+
+Set `webhook.tls.existingSecretName` to a Secret you manage yourself to turn certificate generation
+off. The chart then stops emitting the Secret, and the rendered output becomes byte-for-byte stable
+across renders. The webhook server watches the Secret and reloads the certificate in place when it
+is rotated, so renewal does not require a pod restart.
+
+Because the chart no longer owns a CA in this mode, you must also tell the API server which CA to
+trust, using either `webhook.tls.caBundle` or `webhook.tls.caBundleAnnotations`. Rendering fails if
+neither is set.
+
+With cert-manager issuing the certificate and injecting the CA bundle:
+
+```yaml
+webhook:
+  tls:
+    existingSecretName: akeyless-injector-tls
+    caBundleAnnotations:
+      cert-manager.io/inject-ca-from: "akeyless/akeyless-injector-tls"
+```
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: akeyless-injector-tls
+  namespace: akeyless
+spec:
+  secretName: akeyless-injector-tls
+  dnsNames:
+    - RELEASE_NAME-akeyless-secrets-injection.akeyless.svc
+  issuerRef:
+    name: my-issuer
+    kind: Issuer
+```
+
+With a CA you manage outside the cluster, supply the PEM directly instead — the chart
+base64-encodes it:
+
+```yaml
+webhook:
+  tls:
+    existingSecretName: akeyless-injector-tls
+    caBundle: |
+      -----BEGIN CERTIFICATE-----
+      ...
+      -----END CERTIFICATE-----
+```
+
+The Secret must contain `tls.crt` and `tls.key`, and must exist before the webhook pods start. The
+webhook reads the mounted certificate at startup and exits if it is missing, so pods will crash-loop
+until the issuer has populated the Secret and then recover on their own.
+
 The following tables lists configurable parameters of the vault-secrets-webhook chart and their default values.
 
 | Parameter                         | Description | Default |
@@ -74,6 +133,9 @@ The following tables lists configurable parameters of the vault-secrets-webhook 
 | `mutatingWebhook.objectSelector`  | Object selector for the mutating webhook. Rendered with `tpl`, so values can reference release context. | Excludes the release name |
 | `mutatingWebhook.timeoutSeconds`  | Webhook request timeout in seconds | `10` |
 | `mutatingWebhook.matchConditions` | CEL match conditions for the mutating webhook. Rendered with `tpl`, so values can reference release context. | `[]` |
+| `webhook.tls.existingSecretName`  | Existing Secret with `tls.crt`/`tls.key` for the webhook server. When set, the chart does not generate or manage a certificate. | `""` |
+| `webhook.tls.caBundle`            | PEM CA certificate written to the `MutatingWebhookConfiguration` `caBundle`. Only used with `existingSecretName`. | `""` |
+| `webhook.tls.caBundleAnnotations` | Annotations on the `MutatingWebhookConfiguration`, for controllers that inject `caBundle` themselves (for example cert-manager's ca-injector). Only used with `existingSecretName`. | `{}` |
 | `deployment.nodeSelector`         | Node selector for webhook pods | `null` |
 | `deployment.tolerations`          | Tolerations configuration for webhook pods | `{ enabled: false, data: [] }` |
 | `deployment.affinity`             | Affinity configuration for webhook pods | `{ enabled: false }` |

--- a/charts/akeyless-k8s-secrets-injection/templates/_helpers.tpl
+++ b/charts/akeyless-k8s-secrets-injection/templates/_helpers.tpl
@@ -43,6 +43,28 @@ Create the name of the service account to use
 {{- end -}}
 
 
+{{/*
+Inbound TLS settings for the webhook server.
+*/}}
+{{- define "vault-secrets-webhook.tls" -}}
+{{- (.Values.webhook | default dict).tls | default dict | toYaml -}}
+{{- end -}}
+
+{{/*
+Name of the user-managed serving certificate Secret, or "" when the chart generates its own.
+*/}}
+{{- define "vault-secrets-webhook.existingTLSSecretName" -}}
+{{- $tls := fromYaml (include "vault-secrets-webhook.tls" .) -}}
+{{- $tls.existingSecretName | default "" -}}
+{{- end -}}
+
+{{/*
+Name of the Secret that holds the serving certificate, whether user-managed or chart-generated.
+*/}}
+{{- define "vault-secrets-webhook.tlsSecretName" -}}
+{{- include "vault-secrets-webhook.existingTLSSecretName" . | default (include "vault-secrets-webhook.fullname" .) -}}
+{{- end -}}
+
 {{- define "hpa.api.version" }}
     {{- if .Capabilities.APIVersions.Has "autoscaling/v2" }}
         {{- printf "autoscaling/v2" }}

--- a/charts/akeyless-k8s-secrets-injection/templates/apiservice-webhook.yaml
+++ b/charts/akeyless-k8s-secrets-injection/templates/apiservice-webhook.yaml
@@ -1,8 +1,26 @@
-{{ $ca := genCA "webhook-ca" 3650 }}
 {{ $fullName := include "vault-secrets-webhook.fullname" . }}
-{{ $cn := printf "%s.%s.svc" $fullName .Release.Namespace }}
-{{ $cert := genSignedCert $cn nil (list $cn "") 365 $ca }}
 {{ $mutatingWebhook := .Values.mutatingWebhook | default dict }}
+{{ $tls := fromYaml (include "vault-secrets-webhook.tls" .) }}
+{{ $existingSecret := include "vault-secrets-webhook.existingTLSSecretName" . }}
+{{ $caBundle := $tls.caBundle | default "" }}
+{{ $caBundleAnnotations := $tls.caBundleAnnotations | default dict }}
+{{ $servingCert := dict }}
+{{ $generatedCA := dict }}
+
+{{- if $existingSecret }}
+  {{- if and (not $caBundle) (not $caBundleAnnotations) }}
+    {{- fail "webhook.tls.existingSecretName is set, so the chart no longer generates a CA. Set webhook.tls.caBundle to the PEM CA that signed the certificate, or webhook.tls.caBundleAnnotations to let a controller such as cert-manager's ca-injector populate it." }}
+  {{- end }}
+{{- else }}
+  {{/* No user-managed certificate: generate a self-signed CA and serving certificate.
+       This is non-deterministic and renders differently every time, which is what makes the
+       default configuration drift under GitOps. See webhook.tls in values.yaml. */}}
+  {{- $ca := genCA "webhook-ca" 3650 }}
+  {{- $cn := printf "%s.%s.svc" $fullName .Release.Namespace }}
+  {{- $servingCert = genSignedCert $cn nil (list $cn "") 365 $ca }}
+  {{- $generatedCA = $ca }}
+  {{- $caBundle = $ca.Cert }}
+{{- end }}
 
 apiVersion: v1
 kind: List
@@ -10,20 +28,27 @@ metadata:
   name: {{ $fullName }}-webhook
 items:
 
+{{- if not $existingSecret }}
+
 - apiVersion: v1
   kind: Secret
   metadata:
     name: {{ $fullName }}
     namespace: {{ .Release.Namespace }}
   data:
-    tls.crt: {{ b64enc $cert.Cert }}
-    tls.key: {{ b64enc $cert.Key }}
-    ca.crt: {{ b64enc $ca.Cert }}
+    tls.crt: {{ b64enc $servingCert.Cert }}
+    tls.key: {{ b64enc $servingCert.Key }}
+    ca.crt: {{ b64enc $generatedCA.Cert }}
+{{- end }}
 
 - apiVersion: admissionregistration.k8s.io/v1
   kind: MutatingWebhookConfiguration
   metadata:
     name: {{ $fullName }}
+    {{- with $caBundleAnnotations }}
+    annotations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
   webhooks:
   - name: pods.{{ $fullName }}.admission
     clientConfig:
@@ -31,7 +56,9 @@ items:
         namespace: {{ .Release.Namespace }}
         name: {{ $fullName }}
         path: /pods
-      caBundle: {{ b64enc $ca.Cert }}
+      {{- if $caBundle }}
+      caBundle: {{ b64enc $caBundle }}
+      {{- end }}
     rules:
     - operations:
       - CREATE

--- a/charts/akeyless-k8s-secrets-injection/templates/webhook-deployment.yaml
+++ b/charts/akeyless-k8s-secrets-injection/templates/webhook-deployment.yaml
@@ -40,7 +40,7 @@ spec:
       - name: serving-cert
         secret:
           defaultMode: 420
-          secretName: {{ template "vault-secrets-webhook.fullname" . }}
+          secretName: {{ include "vault-secrets-webhook.tlsSecretName" . }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -50,7 +50,7 @@ spec:
           - name: TLS_PRIVATE_KEY_FILE
             value: /var/serving-cert/tls.key
           - name: TLS_SECRET_NAME
-            value: {{ include "vault-secrets-webhook.fullname" . }}
+            value: {{ include "vault-secrets-webhook.tlsSecretName" . }}
           - name: TLS_SECRET_NAMESPACE
             value: {{ .Release.Namespace | quote }}
           - name: INTERNAL_PORT

--- a/charts/akeyless-k8s-secrets-injection/values.yaml
+++ b/charts/akeyless-k8s-secrets-injection/values.yaml
@@ -77,6 +77,43 @@ mutatingWebhook:
   matchConditions: []
 debug: false
 
+# Inbound TLS for the webhook server (the certificate the Kubernetes API server validates
+# when it calls this webhook on service.internalPort).
+#
+# By default the chart generates a self-signed CA and serving certificate at render time.
+# Because that generation is non-deterministic, every `helm template` / `helm upgrade`
+# produces a new keypair. GitOps controllers such as ArgoCD render the chart on every sync,
+# see the Secret and the MutatingWebhookConfiguration as drifted, and with self-heal enabled
+# push the new values continuously. This causes `tls: bad certificate` handshake errors and
+# rolls the webhook pods on every sync.
+#
+# Set `existingSecretName` to a user-managed Secret (for example one issued by cert-manager)
+# to disable certificate generation entirely and make the rendered output deterministic.
+# The webhook server watches that Secret and hot-reloads the certificate on rotation, so no
+# pod restart is required when the certificate is renewed.
+#
+# When `existingSecretName` is set you must also tell the API server which CA to trust, via
+# either `caBundle` or `caBundleAnnotations`. The chart fails rendering if neither is set.
+#
+# Example, cert-manager issuing the certificate and injecting the CA bundle:
+# webhook:
+#   tls:
+#     existingSecretName: akeyless-injector-tls
+#     caBundleAnnotations:
+#       cert-manager.io/inject-ca-from: "akeyless/akeyless-injector-tls"
+webhook:
+  tls:
+    # Name of an existing Secret in the release namespace containing `tls.crt` and `tls.key`.
+    # When empty the chart generates and manages a self-signed certificate (default behavior).
+    existingSecretName: ""
+    # PEM-encoded CA certificate placed in the MutatingWebhookConfiguration `caBundle`.
+    # Provide the raw PEM; the chart base64-encodes it. Only used with `existingSecretName`.
+    caBundle: ""
+    # Annotations added to the MutatingWebhookConfiguration, for controllers that inject the
+    # `caBundle` themselves (for example cert-manager's ca-injector).
+    # Only used with `existingSecretName`.
+    caBundleAnnotations: {}
+
 gatewayCert:
   #  Specifies an existing secret for gateway tls certificate must include:
   # - tls.crt (base64)


### PR DESCRIPTION
## Problem

`templates/apiservice-webhook.yaml` called `genCA` / `genSignedCert` unconditionally on every render. Those are non-deterministic and Helm holds no state at template time, so each `helm template` emitted a different keypair.

GitOps controllers render the chart on every sync cycle, so with ArgoCD auto-sync and self-heal enabled they saw three things drift continuously:

- the `Secret` holding `tls.crt` / `tls.key`
- the `MutatingWebhookConfiguration` `caBundle`, which must agree with it
- the deployment's `checksum/config` annotation, derived from a sha256 of the rendered template

The first two produce the reported `tls: bad certificate` handshake errors as the API server and the pod fall out of step. The third is not mentioned in the ticket but means the webhook pods were **rolling on every sync**, which likely accounts for symptoms beyond the handshake noise.

It also made cert-manager unusable — the chart overwrote whatever cert-manager issued.

## Change

Adds `webhook.tls.existingSecretName`, pointing the chart at a user-managed Secret containing `tls.crt` / `tls.key`. When set, certificate generation is skipped entirely and the Secret is no longer emitted, so the render becomes byte-for-byte stable.

The CA bundle then comes from either:

- `webhook.tls.caBundle` — raw PEM, base64-encoded by the chart, or
- `webhook.tls.caBundleAnnotations` — annotations on the `MutatingWebhookConfiguration` so a controller such as cert-manager's ca-injector populates `caBundle` itself

Rendering fails if `existingSecretName` is set and neither is configured. A webhook the API server cannot validate breaks pod creation cluster-wide, so this errors loudly rather than rendering something subtly broken.

The deployment's `serving-cert` volume and `TLS_SECRET_NAME` now resolve through a shared helper, keeping the mounted Secret and the one the webhook server watches in sync.

**Default behavior is unchanged** when `webhook.tls.existingSecretName` is empty.

## No server-side change required

The webhook already supports an externally-managed certificate. In `akeyless-kubernetes-webhook-secrets`, `vault-secrets-webhook/cert/cert.go` opens a retry-watch on `TLS_SECRET_NAME` / `TLS_SECRET_NAMESPACE` and hot-swaps the certificate through the `GetCertificate` callback, so rotation needs no pod restart. The ClusterRole in `webhook-role.yaml` already grants `get` / `watch` on secrets. The chart was the only blocker.

## Example

```yaml
webhook:
  tls:
    existingSecretName: akeyless-injector-tls
    caBundleAnnotations:
      cert-manager.io/inject-ca-from: "akeyless/akeyless-injector-tls"
```

## Testing

Rendered and linted locally with Helm 3.16.3:

| Check | Result |
| --- | --- |
| Default render, no values | Secret and `caBundle` still generated; output matches pre-change |
| `helm lint`, default and existing-secret paths | passes |
| cert-manager path | no Secret emitted, annotation present, `caBundle` omitted, deployment points at the user Secret |
| Explicit `caBundle` PEM | base64-encoded into the webhook config |
| **Two consecutive renders, diffed** | **identical — the drift is gone.** Default path still differs per render, as before |
| `existingSecretName` with no CA source | fails with a message naming both remedies |
| Existing `ci/api-key-values.yaml` | still renders |

## Notes for reviewers

- **No `ci/` values file was added for the existing-secret path.** `ct install` would deploy it into kind where the Secret does not exist; the pod would crash-loop on `tls.LoadX509KeyPair` and CI would go red. Covering that path properly needs cert-manager in the kind cluster.
- **Startup ordering:** with an external Secret the pod reads the mounted certificate at startup and exits if absent, so pods crash-loop until the issuer populates the Secret, then recover unaided. Documented in the chart README so it is not re-reported as a bug.
- `lookup` was deliberately not used to stabilize the generated certificate — it returns empty during `helm template`, which is exactly how ArgoCD renders, so it would not fix the drift it appears to fix. Noted in `AGENTS.md`.
- The stale duplicate chart at `akeyless-kubernetes-webhook-secrets/helm-chart/` was left untouched; worth deciding separately whether to mirror or delete it.

Chart version bumped 2.2.0 → 2.3.0. `appVersion` unchanged — no application change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JhCCyr5gSfkraPXL2NsooA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable webhook TLS support using an existing Secret.
  * Added support for explicit CA bundles and CA-injection annotations.
  * Enabled certificate rotation without restarting webhook pods.
  * Preserved automatic self-signed certificate generation as the default.

* **Documentation**
  * Added GitOps, cert-manager, configuration, prerequisites, and failure-behavior guidance.
  * Updated the chart version to 2.3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->