### PR TITLE
remove internal references from the public repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,6 @@
 #Ignore manifest work directory
 manifest_work_dir/
 
-.claude/settings.local.json
-
 Chart.lock
 /charts/*/charts/
 **/charts/*.tgz
@@ -18,6 +16,5 @@ Chart.lock
 values.yaml.tmp
 
 # AI tool configs
-.claude/settings.local.json
 .codex/config.toml
 .cursor/settings.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,0 @@
-# CLAUDE.md
-
-Read `AGENTS.md` for repository guidance.

--- a/charts/akeyless-gateway/Chart.yaml
+++ b/charts/akeyless-gateway/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: akeyless-gateway
-version: 3.3.0
+version: 3.3.1
 description: A Helm chart for Kubernetes that deploys akeyless-gateway
 maintainers:
   - name: Akeyless

--- a/charts/akeyless-gateway/STRICT_SECURITY_POLICY.md
+++ b/charts/akeyless-gateway/STRICT_SECURITY_POLICY.md
@@ -306,4 +306,3 @@ akeyless-ssh:
 For questions or issues:
 - Docs: https://docs.akeyless.io/docs/gateway-chart
 - Slack: #akeyless-support
-- Jira: ASM-17961 (original hardening epic)

--- a/charts/akeyless-gateway/ci/cluster-cache-extra-volumes-values.yaml
+++ b/charts/akeyless-gateway/ci/cluster-cache-extra-volumes-values.yaml
@@ -1,4 +1,3 @@
-# Regression test for the extraVolumes variant of ASM-19002.
 # When persistence is enabled the cache-data item sits at 8 spaces in the
 # Deployment volumes list. extraVolumes was injected with `nindent 6`, so any
 # combination of persistence (or TLS) with extraVolumes produced two list items

--- a/charts/akeyless-gateway/ci/cluster-cache-tls-values.yaml
+++ b/charts/akeyless-gateway/ci/cluster-cache-tls-values.yaml
@@ -1,4 +1,3 @@
-# Regression test for ASM-19002.
 # Standalone cluster cache with TLS enabled *and* persistence enabled renders
 # two items in the Deployment volumes list. Before the fix the tlsVolume helper
 # was injected with `nindent 6` while the cache-data item sat at 8 spaces,

--- a/charts/akeyless-zero-trust-web-access/Chart.yaml
+++ b/charts/akeyless-zero-trust-web-access/Chart.yaml
@@ -16,7 +16,7 @@ maintainers:
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.4.1
+version: 3.4.2
 appVersion: 2.0.1
 icon: https://akeylesslabs.github.io/helm-charts/assets/logo/akl.jpeg
 home: https://www.akeyless.io

--- a/charts/akeyless-zero-trust-web-access/templates/web-worker-deployment.yaml
+++ b/charts/akeyless-zero-trust-web-access/templates/web-worker-deployment.yaml
@@ -173,7 +173,7 @@ spec:
        the in-image defaults (config.go: clientConnectTimeoutSeconds=90,
        intervalSeconds=30s, maxDurationSeconds=4h) take effect. Required
        to defend against "browser opened but client never connected" pods
-       and runaway recordings — see ASM-17214 lifecycle gaps. */}}
+       and runaway recordings. */}}
 {{- if and .Values.sessionRecording .Values.sessionRecording.watchdog }}
   {{- with .Values.sessionRecording.watchdog }}
     {{- if .clientConnectTimeoutSeconds }}

--- a/charts/akeyless-zero-trust-web-access/values.yaml
+++ b/charts/akeyless-zero-trust-web-access/values.yaml
@@ -417,7 +417,7 @@ webWorker:
   # Tighter defaults than the chart used to ship with: failureThreshold * periodSeconds
   # is the upper bound on how long a dead-agent pod stays stranded. With these values,
   # recycle happens within ~30 seconds of the third consecutive failure, vs. the older
-  # 60 * 30s = 30-minute window that hid the ASM-17214 lifecycle regression.
+  # 60 * 30s = 30-minute window that hid the earlier lifecycle regression.
   livenessProbe:
     initialDelaySeconds: 60
     periodSeconds: 10


### PR DESCRIPTION
This repository is public and its charts are published to customers, so internal tracker keys and internal tooling filenames should not appear in it. A customer who clones this repo cannot reach any of them.

## What is removed

```
charts/akeyless-gateway/STRICT_SECURITY_POLICY.md          tracker key in the support section,
                                                           next to a docs link customers can use
charts/akeyless-gateway/ci/cluster-cache-tls-values.yaml    tracker key in a comment
charts/akeyless-gateway/ci/cluster-cache-extra-volumes-...  tracker key in a comment
charts/akeyless-zero-trust-web-access/templates/            tracker key in a template comment
  web-worker-deployment.yaml
charts/akeyless-zero-trust-web-access/values.yaml           tracker key in a comment
.gitignore                                                  AI tool config filename, listed twice
CLAUDE.md                                                   stub file, three lines, pointed at AGENTS.md
```

The surrounding explanations are kept where they carry meaning; only the key is dropped. The security policy's docs link and support channel are untouched.

## What is deliberately left

The GitHub-issue-to-tracker automation under `.github`:

```
.github/workflows/git-issues-jira-automation.yaml
.github/workflows/reusable-git-issues-jira-automation.yaml
.github/scripts/git_issues/generate_jira_issue_data.sh
.github/actionlint.yaml
AGENTS.md
```

That is a working integration wired to repository secrets, mirroring GitHub issues into the tracker and posting to Slack. Removing it would break it. It does publish the tracker hostname and a hardcoded key in the script, so it is worth a separate decision by whoever owns it, but not a drive-by deletion here.

## Chart versions

`akeyless-gateway` 3.3.0 to 3.3.1 and `akeyless-zero-trust-web-access` 3.4.1 to 3.4.2. Chart files changed, so `ct` requires the increment. Nothing else about either chart changes.

## Verification

```
helm lint, both charts                              0 failed
akeyless-gateway helm unittest                      25 passed, 25 total
all 5 gateway ci/ values files                      render
zero-trust-web-access full render vs previous       identical except the chart version label
remaining references outside the automation above   0
```

The zero-trust-web-access chart does not render without credential values, on this branch and on `main` alike; the comparison above uses its own `ci/clusterip-values.yaml`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Akeyless Gateway Helm chart to version 3.4.2.
  * Updated the Akeyless Zero Trust Web Access Helm chart to version 3.4.2.
  * Refreshed repository ignore settings and removed obsolete internal guidance.

* **Documentation**
  * Cleaned up security policy and deployment documentation by removing outdated issue and regression references.
  * Clarified lifecycle and health-check comments without changing runtime configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->