### PR TITLE
let the chart own a cert-manager Certificate for the webhook

### DIFF
--- a/charts/akeyless-k8s-secrets-injection/Chart.yaml
+++ b/charts/akeyless-k8s-secrets-injection/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.3.0
+version: 2.4.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.39.0

--- a/charts/akeyless-k8s-secrets-injection/README.md
+++ b/charts/akeyless-k8s-secrets-injection/README.md
@@ -78,7 +78,34 @@ neither is set. Both belong to this mode only: rendering also fails if `caBundle
 without `existingSecretName`, since the chart writes its own generated CA into `caBundle` there and
 an injector would overwrite it with an unrelated one.
 
-With cert-manager issuing the certificate and injecting the CA bundle:
+#### With cert-manager: let the chart own the Certificate
+
+If cert-manager is installed, this is the shortest correct configuration. The chart renders the
+`Certificate`, points itself at the Secret cert-manager issues, and annotates the
+`MutatingWebhookConfiguration` so ca-injector fills in `caBundle`. No Secret to create by hand:
+
+```yaml
+webhook:
+  tls:
+    certManager:
+      enabled: true
+      issuerRef:
+        name: my-issuer
+        kind: Issuer
+```
+
+The `Certificate` and the Secret are both named `RELEASE_NAME-akeyless-secrets-injection-tls` by
+default; `certificateName` and `secretName` override them independently. `dnsNames` defaults to the
+webhook Service's in-cluster names, and `duration`, `renewBefore` and `privateKey` pass through to
+the `Certificate` untouched. Rendering fails if `issuerRef.name` is empty, or if
+`existingSecretName` is set at the same time, since the two are alternatives.
+
+The drift caveat below still applies: ca-injector writes `caBundle` into the live object, so a
+self-healing controller must be told to leave that field alone.
+
+#### With a Secret you create yourself
+
+Point the chart at an existing Secret and supply the CA bundle separately:
 
 ```yaml
 webhook:

--- a/charts/akeyless-k8s-secrets-injection/templates/_helpers.tpl
+++ b/charts/akeyless-k8s-secrets-injection/templates/_helpers.tpl
@@ -47,9 +47,27 @@ Create the name of the service account to use
 {{- (.Values.webhook | default dict).tls | default dict | toYaml -}}
 {{- end -}}
 
+{{- define "vault-secrets-webhook.certManager" -}}
+{{- $tls := fromYaml (include "vault-secrets-webhook.tls" .) -}}
+{{- $tls.certManager | default dict | toYaml -}}
+{{- end -}}
+
+{{- define "vault-secrets-webhook.certificateName" -}}
+{{- $cm := fromYaml (include "vault-secrets-webhook.certManager" .) -}}
+{{- $cm.certificateName | default (printf "%s-tls" (include "vault-secrets-webhook.fullname" .)) -}}
+{{- end -}}
+
+{{- define "vault-secrets-webhook.certManagerSecretName" -}}
+{{- $cm := fromYaml (include "vault-secrets-webhook.certManager" .) -}}
+{{- if $cm.enabled -}}
+{{- $cm.secretName | default (include "vault-secrets-webhook.certificateName" .) -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "vault-secrets-webhook.existingTLSSecretName" -}}
 {{- $tls := fromYaml (include "vault-secrets-webhook.tls" .) -}}
-{{- $tls.existingSecretName | default "" -}}
+{{- $managed := include "vault-secrets-webhook.certManagerSecretName" . -}}
+{{- $managed | default ($tls.existingSecretName | default "") -}}
 {{- end -}}
 
 {{- define "vault-secrets-webhook.tlsSecretName" -}}

--- a/charts/akeyless-k8s-secrets-injection/templates/apiservice-webhook.yaml
+++ b/charts/akeyless-k8s-secrets-injection/templates/apiservice-webhook.yaml
@@ -6,6 +6,11 @@
 {{ $caBundleAnnotations := $tls.caBundleAnnotations | default dict }}
 {{ $servingCert := dict }}
 {{ $generatedCA := dict }}
+{{ $certManager := fromYaml (include "vault-secrets-webhook.certManager" .) }}
+
+{{- if and $certManager.enabled (not $caBundle) (not $caBundleAnnotations) }}
+  {{- $caBundleAnnotations = dict "cert-manager.io/inject-ca-from" (printf "%s/%s" .Release.Namespace (include "vault-secrets-webhook.certificateName" .)) }}
+{{- end }}
 
 {{- if $existingSecret }}
   {{- if eq $existingSecret $fullName }}

--- a/charts/akeyless-k8s-secrets-injection/templates/webhook-certificate.yaml
+++ b/charts/akeyless-k8s-secrets-injection/templates/webhook-certificate.yaml
@@ -1,0 +1,42 @@
+{{- $cm := fromYaml (include "vault-secrets-webhook.certManager" .) }}
+{{- if $cm.enabled }}
+{{- $fullName := include "vault-secrets-webhook.fullname" . }}
+{{- $tls := fromYaml (include "vault-secrets-webhook.tls" .) }}
+{{- $issuerRef := $cm.issuerRef | default dict }}
+{{- if $tls.existingSecretName }}
+{{- fail "webhook.tls.certManager.enabled and webhook.tls.existingSecretName both set. cert-manager mode already points the chart at the Secret it issues, so the two are alternatives. Keep certManager.enabled for an issued certificate, or existingSecretName for one you manage yourself." }}
+{{- end }}
+{{- if not $issuerRef.name }}
+{{- fail "webhook.tls.certManager.enabled is set but webhook.tls.certManager.issuerRef.name is empty. cert-manager cannot issue without an Issuer or ClusterIssuer to issue from." }}
+{{- end }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "vault-secrets-webhook.certificateName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "vault-secrets-webhook.labels" . | nindent 4 }}
+spec:
+  secretName: {{ include "vault-secrets-webhook.certManagerSecretName" . }}
+  {{- with $cm.duration }}
+  duration: {{ . }}
+  {{- end }}
+  {{- with $cm.renewBefore }}
+  renewBefore: {{ . }}
+  {{- end }}
+  {{- with $cm.privateKey }}
+  privateKey:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  dnsNames:
+  {{- with $cm.dnsNames }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- else }}
+    - {{ printf "%s.%s.svc" $fullName .Release.Namespace }}
+    - {{ printf "%s.%s.svc.cluster.local" $fullName .Release.Namespace }}
+  {{- end }}
+  issuerRef:
+    name: {{ $issuerRef.name }}
+    kind: {{ $issuerRef.kind | default "Issuer" }}
+    group: {{ $issuerRef.group | default "cert-manager.io" }}
+{{- end }}

--- a/charts/akeyless-k8s-secrets-injection/tests/webhook-certmanager_test.yaml
+++ b/charts/akeyless-k8s-secrets-injection/tests/webhook-certmanager_test.yaml
@@ -1,0 +1,170 @@
+suite: akeyless-secrets-injection webhook cert-manager
+release:
+  name: injector
+  namespace: akeyless
+tests:
+  - it: "no Certificate is rendered by default"
+    template: templates/webhook-certificate.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: "enabling cert-manager renders a Certificate for the webhook service name"
+    template: templates/webhook-certificate.yaml
+    set:
+      webhook.tls.certManager.enabled: true
+      webhook.tls.certManager.issuerRef.name: my-issuer
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: injector-akeyless-secrets-injection-tls
+      - equal:
+          path: metadata.namespace
+          value: akeyless
+      - equal:
+          path: spec.secretName
+          value: injector-akeyless-secrets-injection-tls
+      - equal:
+          path: spec.dnsNames
+          value:
+            - injector-akeyless-secrets-injection.akeyless.svc
+            - injector-akeyless-secrets-injection.akeyless.svc.cluster.local
+      - equal:
+          path: spec.issuerRef
+          value:
+            name: my-issuer
+            kind: Issuer
+            group: cert-manager.io
+
+  - it: "cert-manager mode emits no chart Secret and leaves caBundle to the injector"
+    template: templates/apiservice-webhook.yaml
+    set:
+      webhook.tls.certManager.enabled: true
+      webhook.tls.certManager.issuerRef.name: my-issuer
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: items[0].kind
+          value: MutatingWebhookConfiguration
+      - equal:
+          path: items[0].metadata.annotations["cert-manager.io/inject-ca-from"]
+          value: akeyless/injector-akeyless-secrets-injection-tls
+      - isNull:
+          path: items[0].webhooks[0].clientConfig.caBundle
+      - isNull:
+          path: items[1]
+
+  - it: "cert-manager mode mounts the issued Secret and points the watch at it"
+    template: templates/webhook-deployment.yaml
+    set:
+      webhook.tls.certManager.enabled: true
+      webhook.tls.certManager.issuerRef.name: my-issuer
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: serving-cert
+            secret:
+              defaultMode: 420
+              secretName: injector-akeyless-secrets-injection-tls
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TLS_SECRET_NAME
+            value: injector-akeyless-secrets-injection-tls
+
+  - it: "certificateName and secretName can be set independently"
+    template: templates/webhook-certificate.yaml
+    set:
+      webhook.tls.certManager.enabled: true
+      webhook.tls.certManager.issuerRef.name: my-issuer
+      webhook.tls.certManager.certificateName: injector-cert
+      webhook.tls.certManager.secretName: injector-cert-secret
+    asserts:
+      - equal:
+          path: metadata.name
+          value: injector-cert
+      - equal:
+          path: spec.secretName
+          value: injector-cert-secret
+
+  - it: "a custom certificateName is what the CA injection annotation points at"
+    template: templates/apiservice-webhook.yaml
+    set:
+      webhook.tls.certManager.enabled: true
+      webhook.tls.certManager.issuerRef.name: my-issuer
+      webhook.tls.certManager.certificateName: injector-cert
+    asserts:
+      - equal:
+          path: items[0].metadata.annotations["cert-manager.io/inject-ca-from"]
+          value: akeyless/injector-cert
+
+  - it: "dnsNames, duration, renewBefore and privateKey pass through"
+    template: templates/webhook-certificate.yaml
+    set:
+      webhook.tls.certManager.enabled: true
+      webhook.tls.certManager.issuerRef.name: my-issuer
+      webhook.tls.certManager.dnsNames:
+        - injector.example.svc
+      webhook.tls.certManager.duration: 2160h
+      webhook.tls.certManager.renewBefore: 360h
+      webhook.tls.certManager.privateKey:
+        algorithm: ECDSA
+        size: 256
+    asserts:
+      - equal:
+          path: spec.dnsNames
+          value:
+            - injector.example.svc
+      - equal:
+          path: spec.duration
+          value: 2160h
+      - equal:
+          path: spec.renewBefore
+          value: 360h
+      - equal:
+          path: spec.privateKey.algorithm
+          value: ECDSA
+
+  - it: "a ClusterIssuer reference passes through"
+    template: templates/webhook-certificate.yaml
+    set:
+      webhook.tls.certManager.enabled: true
+      webhook.tls.certManager.issuerRef.name: platform-ca
+      webhook.tls.certManager.issuerRef.kind: ClusterIssuer
+    asserts:
+      - equal:
+          path: spec.issuerRef.kind
+          value: ClusterIssuer
+
+  - it: "an explicit caBundle wins over the injection annotation"
+    template: templates/apiservice-webhook.yaml
+    set:
+      webhook.tls.certManager.enabled: true
+      webhook.tls.certManager.issuerRef.name: my-issuer
+      webhook.tls.caBundle: TESTCA
+    asserts:
+      - equal:
+          path: items[0].webhooks[0].clientConfig.caBundle
+          value: VEVTVENB
+      - isNull:
+          path: items[0].metadata.annotations
+
+  - it: "cert-manager together with existingSecretName is rejected"
+    set:
+      webhook.tls.certManager.enabled: true
+      webhook.tls.certManager.issuerRef.name: my-issuer
+      webhook.tls.existingSecretName: akeyless-injector-tls
+    asserts:
+      - failedTemplate:
+          errorPattern: "both set"
+
+  - it: "cert-manager without an issuerRef name is rejected"
+    set:
+      webhook.tls.certManager.enabled: true
+    asserts:
+      - failedTemplate:
+          errorPattern: "issuerRef.name is empty"

--- a/charts/akeyless-k8s-secrets-injection/values.yaml
+++ b/charts/akeyless-k8s-secrets-injection/values.yaml
@@ -82,6 +82,18 @@ webhook:
     existingSecretName: ""
     caBundle: ""
     caBundleAnnotations: {}
+    certManager:
+      enabled: false
+      certificateName: ""
+      secretName: ""
+      dnsNames: []
+      duration: ""
+      renewBefore: ""
+      privateKey: {}
+      issuerRef:
+        name: ""
+        kind: Issuer
+        group: cert-manager.io
 
 gatewayCert:
   #  Specifies an existing secret for gateway tls certificate must include:


### PR DESCRIPTION
Stacks on #430. Closes the half of the problem `existingSecretName` leaves open.

## Why

`existingSecretName` stops the drift, but only for someone who already has a Secret and knows to wire three values together. Leave it unset, which every existing install does, and the chart still calls `genCA`/`genSignedCert` on every render. Confirmed on two consecutive default renders:

```
tls.crt  tls.key  ca.crt  caBundle  checksum/config     all five change
```

So every `helm upgrade`, including one that changes nothing else, rotates the webhook certificate and rolls the pods. Cert and caBundle rotate together in one apply, so this is bounded rather than continuous, but with `failurePolicy: Fail` the rollout window blocks Pod creation in every selected namespace.

Where cert-manager is present the chart can close this itself.

## Change

`webhook.tls.certManager.enabled` renders a `Certificate`, resolves the chart's effective TLS Secret name to the one cert-manager issues, and defaults the CA-injection annotation to that `Certificate`. One flag replaces the three-part manual wiring:

```yaml
webhook:
  tls:
    certManager:
      enabled: true
      issuerRef:
        name: my-issuer
        kind: Issuer
```

The render stays deterministic, since a `Certificate` is a static document. `certificateName` and `secretName` are independent, `dnsNames` defaults to the webhook Service's in-cluster names, and `duration`, `renewBefore` and `privateKey` pass through untouched.

Two guards: an empty `issuerRef.name`, and `certManager` together with `existingSecretName`, which are alternatives rather than layers.

`lookup` is still not the answer here and is not used. It returns empty during `helm template`, which is exactly how ArgoCD renders, so it would fix the CLI path, leave the GitOps path broken, and make the chart's behaviour depend on whether a cluster connection happens to exist.

## Verification

```
helm unittest                                   27 passed, 27 total
positive control, Certificate template removed  7 failed
helm lint  default / api-key / existing-secret / cert-manager   0 failed
cert-manager path rendered twice, diffed        identical
default render                                  no Certificate, output unchanged
```

Chart `3.0.0` to `3.1.0`. Additive; default behaviour untouched.

## Not covered

No `ci/` values file for this path, so the kind layer does not exercise it. cert-manager is not installed in that cluster, the `Certificate` would never be issued and the pod would crash-loop waiting for the Secret. Installing cert-manager in kind and proving a real issued certificate is its own layer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional cert-manager integration for automatic webhook TLS certificate creation and rotation.
  * Added configurable certificate names, DNS names, duration, renewal, private-key settings, and issuer references.
  * Added automatic CA bundle injection when no explicit CA configuration is provided.
  * Updated chart documentation with cert-manager setup and manual Secret guidance.
  * Updated the Helm chart version to 2.4.0.

* **Tests**
  * Added coverage for certificate rendering, customization, CA injection, Secret mounting, and invalid configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->