### PR TITLE
reject the caBundle combinations that silently produce a broken webhook

### DIFF
--- a/charts/akeyless-k8s-secrets-injection/Chart.yaml
+++ b/charts/akeyless-k8s-secrets-injection/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.4.0
+version: 2.5.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.39.0

--- a/charts/akeyless-k8s-secrets-injection/README.md
+++ b/charts/akeyless-k8s-secrets-injection/README.md
@@ -74,9 +74,11 @@ is rotated, so renewal does not require a pod restart.
 
 Because the chart no longer owns a CA in this mode, you must also tell the API server which CA to
 trust, using either `webhook.tls.caBundle` or `webhook.tls.caBundleAnnotations`. Rendering fails if
-neither is set. Both belong to this mode only: rendering also fails if `caBundleAnnotations` is set
-without `existingSecretName`, since the chart writes its own generated CA into `caBundle` there and
-an injector would overwrite it with an unrelated one.
+neither is set, and if both are set, since they are two writers for the same field and the result
+oscillates. Both belong to this mode only: rendering fails if either is set without
+`existingSecretName`, because the chart writes its own generated CA into `caBundle` there, so a
+supplied bundle would be discarded and an injector would overwrite the generated one. A `caBundle`
+that carries no PEM certificate block is rejected as well.
 
 #### With cert-manager: let the chart own the Certificate
 

--- a/charts/akeyless-k8s-secrets-injection/templates/apiservice-webhook.yaml
+++ b/charts/akeyless-k8s-secrets-injection/templates/apiservice-webhook.yaml
@@ -12,6 +12,13 @@
   {{- $caBundleAnnotations = dict "cert-manager.io/inject-ca-from" (printf "%s/%s" .Release.Namespace (include "vault-secrets-webhook.certificateName" .)) }}
 {{- end }}
 
+{{- if and $caBundle $caBundleAnnotations }}
+  {{- fail "webhook.tls.caBundle and webhook.tls.caBundleAnnotations are both set. They are two writers for the same clientConfig.caBundle field: the chart renders the literal value and a CA injector then overwrites it, and a self-healing GitOps controller reverts that on the next sync. The result oscillates and the API server intermittently cannot validate the webhook. Pick one." }}
+{{- end }}
+{{- if and $caBundle (not (contains "-----BEGIN CERTIFICATE-----" $caBundle)) }}
+  {{- fail "webhook.tls.caBundle does not contain a PEM certificate block. The chart base64-encodes this value into clientConfig.caBundle, where an unparsable value blocks Pod creation in every selected namespace once the API server rejects the webhook's certificate. Supply the PEM text of the CA, not a base64 blob, a path or a Secret reference." }}
+{{- end }}
+
 {{- if $existingSecret }}
   {{- if eq $existingSecret $fullName }}
     {{- fail (printf "webhook.tls.existingSecretName must not be %q, the name the chart uses for its own generated Secret. The chart stops emitting that Secret when existingSecretName is set, so helm upgrade on an existing release deletes the Secret the webhook pods mount. Give the user-managed Secret a different name." $fullName) }}
@@ -22,6 +29,9 @@
 {{- else }}
   {{- if $caBundleAnnotations }}
     {{- fail "webhook.tls.caBundleAnnotations applies only when webhook.tls.existingSecretName is set. The chart generates its own CA in this mode and writes the matching caBundle itself, so a CA injector acting on these annotations would replace it with an unrelated CA and the API server could no longer validate the webhook. Set existingSecretName, or remove the annotations." }}
+  {{- end }}
+  {{- if $caBundle }}
+    {{- fail "webhook.tls.caBundle applies only when webhook.tls.existingSecretName is set or cert-manager mode is enabled. The chart generates its own CA here and overwrites this value with it, so the certificate you supplied would be silently discarded and the webhook would keep serving the chart's own. Set existingSecretName, or remove caBundle." }}
   {{- end }}
   {{- $ca := genCA "webhook-ca" 3650 }}
   {{- $cn := printf "%s.%s.svc" $fullName .Release.Namespace }}

--- a/charts/akeyless-k8s-secrets-injection/tests/webhook-certmanager_test.yaml
+++ b/charts/akeyless-k8s-secrets-injection/tests/webhook-certmanager_test.yaml
@@ -145,11 +145,14 @@ tests:
     set:
       webhook.tls.certManager.enabled: true
       webhook.tls.certManager.issuerRef.name: my-issuer
-      webhook.tls.caBundle: TESTCA
+      webhook.tls.caBundle: |
+        -----BEGIN CERTIFICATE-----
+        TESTCA
+        -----END CERTIFICATE-----
     asserts:
       - equal:
           path: items[0].webhooks[0].clientConfig.caBundle
-          value: VEVTVENB
+          value: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tClRFU1RDQQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
       - isNull:
           path: items[0].metadata.annotations
 

--- a/charts/akeyless-k8s-secrets-injection/tests/webhook-tls_test.yaml
+++ b/charts/akeyless-k8s-secrets-injection/tests/webhook-tls_test.yaml
@@ -42,23 +42,24 @@ tests:
             name: TLS_SECRET_NAME
             value: injector-akeyless-secrets-injection
 
-  - it: "caBundle is ignored while the chart still generates its own CA"
-    template: templates/apiservice-webhook.yaml
+  - it: "caBundle without existingSecretName is rejected"
     set:
-      webhook.tls.caBundle: TESTCA
+      webhook.tls.caBundle: |
+        -----BEGIN CERTIFICATE-----
+        TESTCA
+        -----END CERTIFICATE-----
     asserts:
-      - equal:
-          path: items[0].kind
-          value: Secret
-      - notEqual:
-          path: items[1].webhooks[0].clientConfig.caBundle
-          value: VEVTVENB
+      - failedTemplate:
+          errorPattern: "caBundle applies only when"
 
   - it: "existingSecretName with an explicit caBundle emits no Secret"
     template: templates/apiservice-webhook.yaml
     set:
       webhook.tls.existingSecretName: akeyless-injector-tls
-      webhook.tls.caBundle: TESTCA
+      webhook.tls.caBundle: |
+        -----BEGIN CERTIFICATE-----
+        TESTCA
+        -----END CERTIFICATE-----
     asserts:
       - hasDocuments:
           count: 1
@@ -67,7 +68,7 @@ tests:
           value: MutatingWebhookConfiguration
       - equal:
           path: items[0].webhooks[0].clientConfig.caBundle
-          value: VEVTVENB
+          value: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tClRFU1RDQQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
       - isNull:
           path: items[1]
 
@@ -93,7 +94,10 @@ tests:
     template: templates/webhook-deployment.yaml
     set:
       webhook.tls.existingSecretName: akeyless-injector-tls
-      webhook.tls.caBundle: TESTCA
+      webhook.tls.caBundle: |
+        -----BEGIN CERTIFICATE-----
+        TESTCA
+        -----END CERTIFICATE-----
     asserts:
       - contains:
           path: spec.template.spec.volumes
@@ -118,7 +122,10 @@ tests:
   - it: "existingSecretName equal to the chart's own resource name is rejected"
     set:
       webhook.tls.existingSecretName: injector-akeyless-secrets-injection
-      webhook.tls.caBundle: TESTCA
+      webhook.tls.caBundle: |
+        -----BEGIN CERTIFICATE-----
+        TESTCA
+        -----END CERTIFICATE-----
     asserts:
       - failedTemplate:
           errorPattern: "must not be"
@@ -130,3 +137,24 @@ tests:
     asserts:
       - failedTemplate:
           errorPattern: "caBundleAnnotations applies only when"
+
+  - it: "caBundle and caBundleAnnotations together are rejected"
+    set:
+      webhook.tls.existingSecretName: akeyless-injector-tls
+      webhook.tls.caBundle: |
+        -----BEGIN CERTIFICATE-----
+        TESTCA
+        -----END CERTIFICATE-----
+      webhook.tls.caBundleAnnotations:
+        cert-manager.io/inject-ca-from: akeyless/akeyless-injector-tls
+    asserts:
+      - failedTemplate:
+          errorPattern: "two writers for the same"
+
+  - it: "a caBundle that is not a PEM certificate is rejected"
+    set:
+      webhook.tls.existingSecretName: akeyless-injector-tls
+      webhook.tls.caBundle: bm90LWEtcGVt
+    asserts:
+      - failedTemplate:
+          errorPattern: "does not contain a PEM certificate block"


### PR DESCRIPTION
Stacks on #431. Turns four values combinations that render happily and leave the cluster wrong into render failures.

## Why

Each of these produces a webhook the API server cannot validate, or silently discards what the operator asked for. All four passed the gate before this change.

| combination | what happens today |
| --- | --- |
| `caBundle` and `caBundleAnnotations` together | two writers for one field: the chart renders the literal, an injector overwrites it, a self-healing controller reverts that, and validation fails intermittently |
| `caBundle` without `existingSecretName` | overwritten by the generated CA on the next line, so the pinned CA is silently discarded |
| a `caBundle` carrying no PEM block | base64-encoded into `clientConfig` unparsed; an unparsable `caBundle` blocks Pod creation in every selected namespace |
| `caBundleAnnotations` without `existingSecretName` | already rejected in #427; the `caBundle` case above is the same shape and was not |

## Change

Three `fail` guards, placed before the existing ones so the cheaper check reports first. The failure mode in every case is silent and cluster-wide, which is why these are render errors rather than warnings.

**Behaviour change.** `caBundle` without `existingSecretName` used to be ignored, and a test pinned that. It now fails, and that test is replaced. Nobody can be relying on it: the value was introduced in #427 and has never been released.

Test values move to a real PEM block so the shape check is exercised rather than worked around.

## Verification

```
helm unittest                          29 passed, 29 total
positive control, guards stripped      3 failed
helm lint  default / api-key / existing-secret    0 failed
yamllint, ct config                    clean
determinism gate                       two renders identical
```

Chart `3.1.0` to `3.2.0`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation for webhook TLS settings, including required certificate formats and compatible CA source configurations.
  * Helm rendering now provides clear failures for invalid or conflicting TLS options.

* **Bug Fixes**
  * Improved handling of PEM-formatted CA certificates and existing TLS secrets.

* **Documentation**
  * Updated TLS configuration guidance to reflect the new validation requirements.

* **Tests**
  * Expanded coverage for valid PEM certificates and invalid TLS configurations.

* **Chores**
  * Updated the Helm chart version to 2.5.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->