### PR TITLE
akeyless-k8s-secrets-injection: narrow the webhook's secret access to its own namespace

### DIFF
--- a/.github/chart-fixtures/akeyless-k8s-secrets-injection-tls.conf
+++ b/.github/chart-fixtures/akeyless-k8s-secrets-injection-tls.conf
@@ -1,0 +1,1 @@
+injector-tls-ci *.chart-testing.svc

--- a/.github/workflows/chart_test.yaml
+++ b/.github/workflows/chart_test.yaml
@@ -143,6 +143,25 @@ jobs:
             if [[ -d "$fixture_dir" ]]; then
               kubectl apply -f "$fixture_dir/" -n chart-testing
             fi
+            tls_conf=".github/chart-fixtures/${chart_name}-tls.conf"
+            if [[ -f "$tls_conf" ]]; then
+              while read -r secret_name dns_name _rest; do
+                [[ -z "${secret_name}" || "${secret_name}" == \#* ]] && continue
+                openssl req -x509 -newkey rsa:2048 -nodes -days 3650 \
+                  -subj "/CN=${dns_name}" \
+                  -addext "subjectAltName=DNS:${dns_name}" \
+                  -keyout "${RUNNER_TEMP}/${secret_name}.key" \
+                  -out "${RUNNER_TEMP}/${secret_name}.crt" 2>/dev/null
+                kubectl create secret generic "${secret_name}" \
+                  --type=kubernetes.io/tls \
+                  --from-file=tls.crt="${RUNNER_TEMP}/${secret_name}.crt" \
+                  --from-file=tls.key="${RUNNER_TEMP}/${secret_name}.key" \
+                  --from-file=ca.crt="${RUNNER_TEMP}/${secret_name}.crt" \
+                  -n chart-testing --dry-run=client -o yaml | kubectl apply -f -
+                kubectl annotate secret "${secret_name}" -n chart-testing \
+                  cert-manager.io/allow-direct-injection=true --overwrite
+              done < "$tls_conf"
+            fi
           done <<< "$CHANGED_CHARTS"
 
       - name: Run chart-testing install

--- a/charts/akeyless-k8s-secrets-injection/Chart.yaml
+++ b/charts/akeyless-k8s-secrets-injection/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.5.0
+version: 3.0.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.39.0

--- a/charts/akeyless-k8s-secrets-injection/README.md
+++ b/charts/akeyless-k8s-secrets-injection/README.md
@@ -59,6 +59,21 @@ mutatingWebhook:
   failurePolicy: Fail
 ```
 
+### Upgrading to 3.0.0
+
+The webhook's permission to read Secrets is now a namespaced `Role` in the release namespace
+instead of a cluster-wide `ClusterRole`. The webhook only ever reads its own serving-certificate
+Secret, so the cluster-wide grant was never used.
+
+A default install now creates no cluster-scoped objects at all. The `ClusterRole` is created only
+when `restartRollout.enabled` is set, since that feature does list Deployments, DaemonSets,
+StatefulSets and Namespaces across the cluster. All four RBAC objects are named after the release,
+so the chart can now be installed more than once in the same cluster.
+
+The old objects were named `akyeless-injector-role` and `akeyless-injector-role-binding`, fixed
+strings shared by every release. `helm upgrade` removes them. If you have your own RoleBinding,
+policy or aggregation rule referring to either name, update it before upgrading.
+
 ### Webhook serving certificate (GitOps / cert-manager)
 
 By default the chart generates a self-signed CA and serving certificate while rendering. That

--- a/charts/akeyless-k8s-secrets-injection/ci/existing-secret-values.yaml
+++ b/charts/akeyless-k8s-secrets-injection/ci/existing-secret-values.yaml
@@ -1,0 +1,12 @@
+replicaCount: 1
+
+env:
+  AKEYLESS_ACCESS_TYPE: api_key
+  AKEYLESS_ACCESS_ID: p-12345678911123
+  AKEYLESS_API_KEY: ZHVtbXktYXBpLWtleQ==  # betterleaks:allow
+
+webhook:
+  tls:
+    existingSecretName: injector-tls-ci
+    caBundleAnnotations:
+      cert-manager.io/inject-ca-from-secret: chart-testing/injector-tls-ci

--- a/charts/akeyless-k8s-secrets-injection/templates/webhook-role.yaml
+++ b/charts/akeyless-k8s-secrets-injection/templates/webhook-role.yaml
@@ -1,13 +1,38 @@
-
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
-  name: akyeless-injector-role
+  name: {{ template "vault-secrets-webhook.fullname" . }}-role
+  namespace: {{ .Release.Namespace }}
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
   verbs: ["get", "watch"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "vault-secrets-webhook.fullname" . }}-role-binding
+  namespace: {{ .Release.Namespace }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "vault-secrets-webhook.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
+roleRef:
+  kind: Role
+  name: {{ template "vault-secrets-webhook.fullname" . }}-role
+  apiGroup: rbac.authorization.k8s.io
+
 {{- if .Values.restartRollout.enabled }}
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "vault-secrets-webhook.fullname" . }}-restart-rollout
+rules:
 - apiGroups: ["apps"]
   resources: ["deployments", "daemonsets", "statefulsets"]
   verbs: ["get", "list", "patch", "watch"]
@@ -20,19 +45,19 @@ rules:
 - apiGroups: [""]
   resources: ["events"]
   verbs: ["patch", "create"]
-{{end}}
 
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: akeyless-injector-role-binding
+  name: {{ template "vault-secrets-webhook.fullname" . }}-restart-rollout
 subjects:
 - kind: ServiceAccount
   name: {{ template "vault-secrets-webhook.serviceAccountName" . }}
   namespace: {{ .Release.Namespace | quote }}
 roleRef:
   kind: ClusterRole
-  name: akyeless-injector-role
+  name: {{ template "vault-secrets-webhook.fullname" . }}-restart-rollout
   apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/akeyless-k8s-secrets-injection/tests/webhook-rbac_test.yaml
+++ b/charts/akeyless-k8s-secrets-injection/tests/webhook-rbac_test.yaml
@@ -1,0 +1,128 @@
+suite: akeyless-secrets-injection webhook RBAC
+templates:
+  - templates/webhook-role.yaml
+release:
+  name: injector
+  namespace: akeyless
+tests:
+  - it: "a default install creates no cluster-scoped RBAC"
+    asserts:
+      - hasDocuments:
+          count: 2
+      - isKind:
+          of: Role
+        documentIndex: 0
+      - isKind:
+          of: RoleBinding
+        documentIndex: 1
+
+  - it: "the secrets grant is namespaced to the release"
+    asserts:
+      - equal:
+          path: metadata.name
+          value: injector-akeyless-secrets-injection-role
+        documentIndex: 0
+      - equal:
+          path: metadata.namespace
+          value: akeyless
+        documentIndex: 0
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["secrets"]
+            verbs: ["get", "watch"]
+        documentIndex: 0
+
+  - it: "the binding points at this release's Role and ServiceAccount"
+    asserts:
+      - equal:
+          path: roleRef.kind
+          value: Role
+        documentIndex: 1
+      - equal:
+          path: roleRef.name
+          value: injector-akeyless-secrets-injection-role
+        documentIndex: 1
+      - contains:
+          path: subjects
+          content:
+            kind: ServiceAccount
+            name: injector-akeyless-secrets-injection
+            namespace: akeyless
+        documentIndex: 1
+
+  - it: "restartRollout adds a release-scoped ClusterRole and binding"
+    set:
+      restartRollout.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 4
+      - isKind:
+          of: ClusterRole
+        documentIndex: 2
+      - equal:
+          path: metadata.name
+          value: injector-akeyless-secrets-injection-restart-rollout
+        documentIndex: 2
+      - isKind:
+          of: ClusterRoleBinding
+        documentIndex: 3
+      - equal:
+          path: metadata.name
+          value: injector-akeyless-secrets-injection-restart-rollout
+        documentIndex: 3
+      - equal:
+          path: roleRef.name
+          value: injector-akeyless-secrets-injection-restart-rollout
+        documentIndex: 3
+
+  - it: "the restartRollout ClusterRole never carries the secrets grant"
+    set:
+      restartRollout.enabled: true
+    asserts:
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["secrets"]
+            verbs: ["get", "watch"]
+        documentIndex: 2
+
+  - it: "a second release in the same cluster gets its own names"
+    release:
+      name: other
+      namespace: other-ns
+    set:
+      restartRollout.enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: other-akeyless-secrets-injection-role
+        documentIndex: 0
+      - equal:
+          path: metadata.namespace
+          value: other-ns
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: other-akeyless-secrets-injection-restart-rollout
+        documentIndex: 2
+
+  - it: "fullnameOverride scopes every RBAC name"
+    set:
+      fullnameOverride: my-injector
+      restartRollout.enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: my-injector-role
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: my-injector-role-binding
+        documentIndex: 1
+      - equal:
+          path: metadata.name
+          value: my-injector-restart-rollout
+        documentIndex: 2


### PR DESCRIPTION
Top of the stack, and the only breaking change in it. Chart `2.5.0` to `3.0.0`.

**Not part of.** It was found while adding that ticket's test coverage and was originally bundled into #427; it is split out here so the customer's feature is an additive `2.3.0` and this gets judged on its own risk.

## The bug

The `ClusterRole` and `ClusterRoleBinding` had fixed names shared by every release, so a second install of this chart in any cluster fails on Helm ownership. **A customer cannot run the injector in two namespaces today.**

## Why the fix is not a rename

The `ClusterRole` existed to grant `get`/`watch` on secrets cluster-wide, and the webhook never used it:

| evidence | result |
| --- | --- |
| `cert.go:95` | `Secrets(cm.tlsSecretNamespace).Watch(...)` — its own namespace |
| controller-runtime `List` calls | `NamespaceList`, `DeploymentList`, `DaemonSetList`, `StatefulSetList` — no `SecretList` |
| `GetListItemsForRestart` | the Akeyless API, not the cluster, despite `listSecretChanged` calling it |
| the webhook repo's own copy of this chart | `ClusterRole` gated on `restartRollout`, and carries no `secrets` rule |

So the grant moves to a namespaced `Role`/`RoleBinding` in the release namespace, and the `ClusterRole` remains only for `restartRollout`, which genuinely reads across the cluster. A default install now creates **no cluster-scoped RBAC** — the collision is removed by construction rather than worked around. The chart still creates a cluster-scoped `MutatingWebhookConfiguration`; that is unrelated and unchanged.

## Breaking

`akyeless-injector-role` and `akeyless-injector-role-binding` are gone. `helm upgrade` removes them. The README has an "Upgrading to 3.0.0" section naming both, for anyone with an external RoleBinding, policy or aggregation rule pointing at either.

## Verification

```
helm unittest                                  29 passed, 29 total  (7 new RBAC cases)
  RBAC suite vs pre-change main                7 failed, correctly
helm lint                                      0 failed
default install, cluster-scoped RBAC objects   0
```

Seven cases pin the shape, including that the `restartRollout` `ClusterRole` never carries the secrets grant, and that a second release in the same cluster gets its own names.

