### PR TITLE
ASM-19563: configurable cluster DNS domain in akeyless-gateway

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,3 @@
 # CLAUDE.md
 
-Read `AGENTS.md` for repository guidance.
+@AGENTS.md

--- a/charts/akeyless-gateway/Chart.yaml
+++ b/charts/akeyless-gateway/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: akeyless-gateway
-version: 3.3.2
+version: 3.3.1
 description: A Helm chart for Kubernetes that deploys akeyless-gateway
 maintainers:
   - name: Akeyless

--- a/charts/akeyless-gateway/Chart.yaml
+++ b/charts/akeyless-gateway/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: akeyless-gateway
-version: 3.3.1
+version: 3.3.2
 description: A Helm chart for Kubernetes that deploys akeyless-gateway
 maintainers:
   - name: Akeyless

--- a/charts/akeyless-gateway/Chart.yaml
+++ b/charts/akeyless-gateway/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: akeyless-gateway
-version: 3.3.0
+version: 3.3.1
 description: A Helm chart for Kubernetes that deploys akeyless-gateway
 maintainers:
   - name: Akeyless

--- a/charts/akeyless-gateway/README.md
+++ b/charts/akeyless-gateway/README.md
@@ -37,10 +37,10 @@ helm install gateway akeyless/akeyless-gateway
 
 ## Cluster DNS Domain
 
-Clusters whose DNS search domain is not the default `svc.cluster.local` (for example `svc.taz-iam-int-1.local`) must set `clusterDomain` so SRA internal service URLs resolve correctly:
+Clusters whose DNS search domain is not the default `svc.cluster.local` (for example `svc.custom.local`) must set `clusterDomain` so SRA internal service URLs resolve correctly:
 
 ```yaml
-clusterDomain: taz-iam-int-1.local
+clusterDomain: custom.local
 ```
 
 ## Extra Volumes and Volume Mounts

--- a/charts/akeyless-gateway/README.md
+++ b/charts/akeyless-gateway/README.md
@@ -35,6 +35,14 @@ To install the chart run the following:
 helm install gateway akeyless/akeyless-gateway
 ```
 
+## Cluster DNS Domain
+
+Clusters whose DNS search domain is not the default `svc.cluster.local` (for example `svc.taz-iam-int-1.local`) must set `clusterDomain` so SRA internal service URLs resolve correctly:
+
+```yaml
+clusterDomain: taz-iam-int-1.local
+```
+
 ## Extra Volumes and Volume Mounts
 
 To add custom Kubernetes volumes to the Gateway pod and mount them into the Gateway container, configure `gateway.deployment.extraVolumes` and `gateway.deployment.extraVolumeMounts`:

--- a/charts/akeyless-gateway/templates/_helpers.tpl
+++ b/charts/akeyless-gateway/templates/_helpers.tpl
@@ -543,29 +543,33 @@ app.kubernetes.io/instance: {{ .Release.Name }}
     value: "true"
 {{- end -}}
 
+{{- define "akeyless-gateway.clusterSvcDomain" -}}
+svc.{{ default "cluster.local" .Values.clusterDomain }}
+{{- end -}}
+
 {{- define "akeyless-gateway.unifiedGatewayConfig" }}
   {{ include "akeyless-gateway.unifiedGatewayFlag" . }}
   - name: GATEWAY_URL
-    value: "http://{{ include "akeyless-gateway.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:8000"
+    value: "http://{{ include "akeyless-gateway.fullname" . }}.{{ .Release.Namespace }}.{{ include "akeyless-gateway.clusterSvcDomain" . }}:8000"
   - name: INTERNAL_GATEWAY_API
-    value: "http://{{ include "akeyless-gateway.fullname" . }}-internal.{{ .Release.Namespace }}.svc.cluster.local:8080"
+    value: "http://{{ include "akeyless-gateway.fullname" . }}-internal.{{ .Release.Namespace }}.{{ include "akeyless-gateway.clusterSvcDomain" . }}:8080"
 {{- end -}}
 
 {{- define "akeyless-gateway.SraWebServiceConfig" }}
   - name: REMOTE_ACCESS_WEB_SERVICE_INTERNAL_URL
-    value: "http://web-{{ include "akeyless-gateway.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:8888"
+    value: "http://web-{{ include "akeyless-gateway.fullname" . }}.{{ .Release.Namespace }}.{{ include "akeyless-gateway.clusterSvcDomain" . }}:8888"
 {{- end -}}
 
 {{- define "akeyless-gateway.SraSshServiceConfig" }}
   - name: REMOTE_ACCESS_SSH_SERVICE_INTERNAL_URL
-    value: "http://ssh-{{ include "akeyless-gateway.fullname" . }}-internal.{{ .Release.Namespace }}.svc.cluster.local:9900"
+    value: "http://ssh-{{ include "akeyless-gateway.fullname" . }}-internal.{{ .Release.Namespace }}.{{ include "akeyless-gateway.clusterSvcDomain" . }}:9900"
 {{- end -}}
 
 {{- define "akeyless-gateway.unifiedGatewaySraWebConfig" }}
   {{ include "akeyless-gateway.unifiedGatewayConfig" . }}
   {{ include "akeyless-gateway.SraSshServiceConfig" . }}
   - name: REMOTE_ACCESS_SSH_ENDPOINT
-    value: "ssh-{{ include "akeyless-gateway.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.sra.sshConfig.service.port }}"
+    value: "ssh-{{ include "akeyless-gateway.fullname" . }}.{{ .Release.Namespace }}.{{ include "akeyless-gateway.clusterSvcDomain" . }}:{{ .Values.sra.sshConfig.service.port }}"
 {{- end -}}
 
 {{- define "akeyless-gateway.unifiedGatewaySraGatewayConfig" }}

--- a/charts/akeyless-gateway/templates/secrets.yaml
+++ b/charts/akeyless-gateway/templates/secrets.yaml
@@ -45,14 +45,15 @@ data:
 {{- $tlsSecretName = (tpl .Values.cacheHA.tls.secretName .) }}
 {{- $validityDays = ((.Values.cacheHA.tls).certValidityDays | int) | default 1825 }}
 {{- end }}
+{{- $clusterSvcDomain := include "akeyless-gateway.clusterSvcDomain" . }}
 {{- $altNames := list
-  (printf "%s.%s.svc.cluster.local" $fullname .Release.Namespace)
-  (printf "*.%s.%s.svc.cluster.local" $fullname .Release.Namespace)
+  (printf "%s.%s.%s" $fullname .Release.Namespace $clusterSvcDomain)
+  (printf "*.%s.%s.%s" $fullname .Release.Namespace $clusterSvcDomain)
   (printf "%s.%s.svc" $fullname .Release.Namespace)
   (printf "*.%s.%s.svc" $fullname .Release.Namespace)
   (printf "%s.%s" $fullname .Release.Namespace)
   (printf "*.%s.%s" $fullname .Release.Namespace)
-  (printf "*.%s.svc.cluster.local" .Release.Namespace)
+  (printf "*.%s.%s" .Release.Namespace $clusterSvcDomain)
   (printf "*.%s.svc" .Release.Namespace)
   (printf "*.%s" .Release.Namespace)
   "127.0.0.1"
@@ -61,7 +62,7 @@ data:
 }}
 {{- if .Values.cacheHA.enabled }}
   {{- range $i := until (.Values.cacheHA.replicas | int) }}
-    {{- $altNames = append $altNames (printf "%s-announce-%d.%s.svc.cluster.local" $fullname $i $.Release.Namespace) }}
+    {{- $altNames = append $altNames (printf "%s-announce-%d.%s.%s" $fullname $i $.Release.Namespace $clusterSvcDomain) }}
     {{- $altNames = append $altNames (printf "%s-announce-%d.%s.svc" $fullname $i $.Release.Namespace) }}
     {{- $altNames = append $altNames (printf "%s-announce-%d.%s" $fullname $i $.Release.Namespace) }}
   {{- end }}

--- a/charts/akeyless-gateway/tests/cluster-domain_test.yaml
+++ b/charts/akeyless-gateway/tests/cluster-domain_test.yaml
@@ -1,0 +1,29 @@
+suite: akeyless-gateway clusterDomain
+set:
+  sra.enabled: true
+  sra.sshConfig.CAPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC7 test
+tests:
+  - it: defaults internal service URLs to svc.cluster.local
+    template: templates/akeyless-secure-remote-access/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: INTERNAL_GATEWAY_API
+            value: http://RELEASE-NAME-akeyless-gateway-internal.NAMESPACE.svc.cluster.local:8080
+
+  - it: uses custom clusterDomain in internal service URLs
+    template: templates/akeyless-secure-remote-access/deployment.yaml
+    set:
+      clusterDomain: taz-iam-int-1.local
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: INTERNAL_GATEWAY_API
+            value: http://RELEASE-NAME-akeyless-gateway-internal.NAMESPACE.svc.taz-iam-int-1.local:8080
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GATEWAY_URL
+            value: http://RELEASE-NAME-akeyless-gateway.NAMESPACE.svc.taz-iam-int-1.local:8000

--- a/charts/akeyless-gateway/tests/cluster-domain_test.yaml
+++ b/charts/akeyless-gateway/tests/cluster-domain_test.yaml
@@ -15,15 +15,36 @@ tests:
   - it: uses custom clusterDomain in internal service URLs
     template: templates/akeyless-secure-remote-access/deployment.yaml
     set:
-      clusterDomain: taz-iam-int-1.local
+      clusterDomain: custom.local
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: INTERNAL_GATEWAY_API
-            value: http://RELEASE-NAME-akeyless-gateway-internal.NAMESPACE.svc.taz-iam-int-1.local:8080
+            value: http://RELEASE-NAME-akeyless-gateway-internal.NAMESPACE.svc.custom.local:8080
       - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: GATEWAY_URL
-            value: http://RELEASE-NAME-akeyless-gateway.NAMESPACE.svc.taz-iam-int-1.local:8000
+            value: http://RELEASE-NAME-akeyless-gateway.NAMESPACE.svc.custom.local:8000
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REMOTE_ACCESS_SSH_SERVICE_INTERNAL_URL
+            value: http://ssh-RELEASE-NAME-akeyless-gateway-internal.NAMESPACE.svc.custom.local:9900
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REMOTE_ACCESS_SSH_ENDPOINT
+            value: ssh-RELEASE-NAME-akeyless-gateway.NAMESPACE.svc.custom.local:22
+
+  - it: gateway deployment uses custom clusterDomain for SRA web internal URL
+    template: templates/deployment.yaml
+    set:
+      clusterDomain: custom.local
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REMOTE_ACCESS_WEB_SERVICE_INTERNAL_URL
+            value: http://web-RELEASE-NAME-akeyless-gateway.NAMESPACE.svc.custom.local:8888

--- a/charts/akeyless-gateway/values.schema.json
+++ b/charts/akeyless-gateway/values.schema.json
@@ -1,6 +1,11 @@
 {
     "$schema": "https://json-schema.org/draft-07/schema#",
     "properties": {
+      "clusterDomain": {
+        "type": "string",
+        "default": "cluster.local",
+        "description": "Kubernetes cluster DNS domain suffix for internal service URLs (e.g. cluster.local yields <svc>.<ns>.svc.cluster.local)."
+      },
       "globalConfig": {
         "type": "object",
         "properties": {

--- a/charts/akeyless-gateway/values.schema.json
+++ b/charts/akeyless-gateway/values.schema.json
@@ -4,7 +4,9 @@
       "clusterDomain": {
         "type": "string",
         "default": "cluster.local",
-        "description": "Kubernetes cluster DNS domain suffix for internal service URLs (e.g. cluster.local yields <svc>.<ns>.svc.cluster.local)."
+        "description": "Kubernetes cluster DNS domain suffix for internal service URLs (e.g. cluster.local yields <svc>.<ns>.svc.cluster.local).",
+        "maxLength": 253,
+        "pattern": "^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\\.)+[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$|^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$"
       },
       "globalConfig": {
         "type": "object",

--- a/charts/akeyless-gateway/values.yaml
+++ b/charts/akeyless-gateway/values.yaml
@@ -2,6 +2,12 @@
 ## Global ##
 ############
 
+## Kubernetes cluster DNS domain suffix for internal service URLs.
+## Default clusters use cluster.local (service FQDN: <svc>.<ns>.svc.cluster.local).
+## Set to your cluster's DNS domain when it differs (e.g. taz-iam-int-1.local → svc.taz-iam-int-1.local).
+##
+clusterDomain: cluster.local
+
 ## Strict Security Policy Toggle (Kyverno/PSA compliance)
 ## When enabled, enforces non-root execution (UID/GID/fsGroup hardcoded to 1001),
 ## capability drops, resource limits, and hardening on Gateway, Cache, and SRA Web.

--- a/charts/akeyless-gateway/values.yaml
+++ b/charts/akeyless-gateway/values.yaml
@@ -4,7 +4,7 @@
 
 ## Kubernetes cluster DNS domain suffix for internal service URLs.
 ## Default clusters use cluster.local (service FQDN: <svc>.<ns>.svc.cluster.local).
-## Set to your cluster's DNS domain when it differs (e.g. taz-iam-int-1.local → svc.taz-iam-int-1.local).
+## Set to your cluster's DNS domain when it differs (e.g. custom.local → svc.custom.local).
 ##
 clusterDomain: cluster.local
 


### PR DESCRIPTION
## Summary
- Add top-level `clusterDomain` value (default `cluster.local`) so internal SRA/gateway service URLs use `svc.<clusterDomain>` instead of hardcoded `svc.cluster.local`.
- Update cache TLS cert SANs in `secrets.yaml` to match the configured domain.
- Add `values.schema.json` entry, README note, and helm-unittest coverage.
- Simplify `CLAUDE.md` to `@AGENTS.md` instead of the redundant prose line.

Fixes DNS resolution failures in clusters with non-default DNS domains.

## Test plan
- [x] `helm lint charts/akeyless-gateway`
- [x] `helm unittest charts/akeyless-gateway` (27 tests pass)
- [x] `helm template` with `clusterDomain: custom.local` renders `svc.custom.local` URLs


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring a custom Kubernetes DNS domain for internal service URLs.
  - Updated gateway, SRA, SSH, and related TLS hostnames to use the configured domain.

- **Documentation**
  - Added configuration guidance and an example for the new `clusterDomain` setting.

- **Bug Fixes**
  - Improved compatibility with Kubernetes clusters using non-default DNS domains.

- **Chores**
  - Updated the Helm chart version to 3.3.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->