### PR TITLE
ASM-15500: render topologySpreadConstraints without requiring affinity

### DIFF
--- a/charts/akeyless-gateway/Chart.yaml
+++ b/charts/akeyless-gateway/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: akeyless-gateway
-version: 3.4.1
+version: 3.4.2
 description: A Helm chart for Kubernetes that deploys akeyless-gateway
 maintainers:
   - name: Akeyless

--- a/charts/akeyless-gateway/ci/topology-spread-values.yaml
+++ b/charts/akeyless-gateway/ci/topology-spread-values.yaml
@@ -1,0 +1,21 @@
+globalConfig:
+  gatewayAuth:
+    gatewayAccessType: access_key
+    gatewayCredentialsExistingSecret: akeyless-auth
+
+gateway:
+  service:
+    type: ClusterIP
+  deployment:
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: akeyless-gateway
+
+sra:
+  sshConfig:
+    service:
+      type: ClusterIP

--- a/charts/akeyless-gateway/templates/akeyless-cache/cache.yaml
+++ b/charts/akeyless-gateway/templates/akeyless-cache/cache.yaml
@@ -43,10 +43,10 @@ spec:
       {{- if .Values.gateway.deployment.affinity.enabled }}
       affinity:
         {{- toYaml .Values.gateway.deployment.affinity.data | nindent 8 }}
+      {{- end }}
       {{- if .Values.gateway.deployment.topologySpreadConstraints }}
       topologySpreadConstraints:
         {{- toYaml .Values.gateway.deployment.topologySpreadConstraints | nindent 8 }}
-      {{- end }}
       {{- end }}
       {{- if .Values.strictSecurityPolicy.enabled }}
       securityContext:

--- a/charts/akeyless-gateway/templates/deployment.yaml
+++ b/charts/akeyless-gateway/templates/deployment.yaml
@@ -42,10 +42,10 @@ spec:
       {{- if .Values.gateway.deployment.affinity.enabled }}
       affinity:
       {{- toYaml .Values.gateway.deployment.affinity.data | nindent 8 }}
+      {{- end }}
       {{- if .Values.gateway.deployment.topologySpreadConstraints }}
       topologySpreadConstraints:
       {{- toYaml .Values.gateway.deployment.topologySpreadConstraints | nindent 8 }}
-      {{- end }}
       {{- end }}
       {{- if or .Values.gateway.deployment.securityContext.enabled .Values.strictSecurityPolicy.enabled }}
       securityContext:

--- a/charts/akeyless-gateway/tests/topology-spread-constraints_test.yaml
+++ b/charts/akeyless-gateway/tests/topology-spread-constraints_test.yaml
@@ -1,0 +1,57 @@
+suite: akeyless-gateway topologySpreadConstraints
+set:
+  gateway.deployment.topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/name: akeyless-gateway
+tests:
+  - it: gateway renders topologySpreadConstraints with affinity at its default
+    template: templates/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].topologyKey
+          value: topology.kubernetes.io/zone
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].whenUnsatisfiable
+          value: ScheduleAnyway
+      - notExists:
+          path: spec.template.spec.affinity
+
+  - it: cache renders topologySpreadConstraints with affinity at its default
+    template: templates/akeyless-cache/cache.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].topologyKey
+          value: topology.kubernetes.io/zone
+      - notExists:
+          path: spec.template.spec.affinity
+
+  - it: gateway renders affinity and topologySpreadConstraints together
+    template: templates/deployment.yaml
+    set:
+      gateway.deployment.affinity.enabled: true
+      gateway.deployment.affinity.data:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: In
+                    values: [linux]
+    asserts:
+      - exists:
+          path: spec.template.spec.affinity.nodeAffinity
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].maxSkew
+          value: 1
+
+  - it: gateway omits topologySpreadConstraints when unset
+    template: templates/deployment.yaml
+    set:
+      gateway.deployment.topologySpreadConstraints: []
+    asserts:
+      - notExists:
+          path: spec.template.spec.topologySpreadConstraints


### PR DESCRIPTION
## Problem

`templates/deployment.yaml` and `templates/akeyless-cache/cache.yaml` nested the `topologySpreadConstraints` block inside the affinity conditional:

```
{{- if .Values.gateway.deployment.affinity.enabled }}
affinity:
  {{- toYaml .Values.gateway.deployment.affinity.data | nindent 8 }}
  {{- if .Values.gateway.deployment.topologySpreadConstraints }}
  topologySpreadConstraints:
    {{- toYaml .Values.gateway.deployment.topologySpreadConstraints | nindent 8 }}
  {{- end }}
{{- end }}
```

`gateway.deployment.affinity.enabled` defaults to `false` (values.yaml:287), so setting `gateway.deployment.topologySpreadConstraints` on a default install rendered nothing. No error, no warning, the field simply absent from the pod spec.

## Repro

Values setting only the constraint:

```
helm template gw . -f tsc.yaml | grep -c topologySpreadConstraints
0

helm template gw . -f tsc.yaml --set gateway.deployment.affinity.enabled=true | grep -c topologySpreadConstraints
2
```

After this change: 2 in both cases.

## Fix

Close the affinity block before the constraint block, which is what the two SRA templates already do. `ecaab53` did that for SRA web and ssh and missed these two. The nesting came in with `19d81b2` (#316). One line moved per template.

## Tests

`tests/topology-spread-constraints_test.yaml`, four cases at render level:

- gateway renders constraints with affinity untouched
- cache renders constraints with affinity untouched
- affinity and constraints render together when both are set
- constraints omitted when unset

`ci/topology-spread-values.yaml` adds a `ct install`, so the field is validated by a real API server rather than only by a render assertion.

Both were checked against the old templates: the unit suite fails 2 of 4, the install fixture renders 0 instead of 2. Full chart suite is 32 tests across 6 suites, all passing.

## Compatibility

Backward compatible. Setting both keys today gives byte-identical output. Chart 3.4.1 to 3.4.2.

## Out of scope

- `akeyless-zero-trust-web-access` has no constraint support on 3 pod specs
- `akeyless-api-gateway` has none, and is being retired
- the standalone `akeyless-secure-remote-access` chart has none on 6 pod specs, while the same workloads embedded here do
- `clusterCache` reads `gateway.deployment.*` for its whole scheduling surface, so it cannot be placed independently of the gateway. Left alone here to keep this a fix rather than a behaviour change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed topology spread constraints so they work correctly whether or not pod affinity is configured.
  - Ensured topology settings are applied independently for gateway and cache deployments.

- **Tests**
  - Added coverage for default configurations, affinity-enabled deployments, and cases where topology constraints are omitted.

- **Chores**
  - Updated the Helm chart version to 3.4.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->