### PR TITLE
ASM-15500: let the cluster cache be scheduled independently of the gateway

### DIFF
--- a/charts/akeyless-gateway/Chart.yaml
+++ b/charts/akeyless-gateway/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: akeyless-gateway
-version: 3.4.1
+version: 3.4.2
 description: A Helm chart for Kubernetes that deploys akeyless-gateway
 maintainers:
   - name: Akeyless

--- a/charts/akeyless-gateway/Chart.yaml
+++ b/charts/akeyless-gateway/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: akeyless-gateway
-version: 3.4.2
+version: 3.5.0
 description: A Helm chart for Kubernetes that deploys akeyless-gateway
 maintainers:
   - name: Akeyless

--- a/charts/akeyless-gateway/ci/topology-spread-values.yaml
+++ b/charts/akeyless-gateway/ci/topology-spread-values.yaml
@@ -1,0 +1,21 @@
+globalConfig:
+  gatewayAuth:
+    gatewayAccessType: access_key
+    gatewayCredentialsExistingSecret: akeyless-auth
+
+gateway:
+  service:
+    type: ClusterIP
+  deployment:
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: akeyless-gateway
+
+sra:
+  sshConfig:
+    service:
+      type: ClusterIP

--- a/charts/akeyless-gateway/templates/akeyless-cache/cache.yaml
+++ b/charts/akeyless-gateway/templates/akeyless-cache/cache.yaml
@@ -32,21 +32,26 @@ spec:
         {{- include "akeyless-gateway.clusterCache.labels" . | nindent 8 }}
     spec:
       {{- include "cache.imagePullSecrets" . | indent 2 }}
-      {{- if .Values.gateway.deployment.tolerations }}
+      {{- $cache := .Values.globalConfig.clusterCache }}
+      {{- $tolerations := ternary .Values.gateway.deployment.tolerations $cache.tolerations (kindIs "invalid" $cache.tolerations) }}
+      {{- $nodeSelector := ternary .Values.gateway.deployment.nodeSelector $cache.nodeSelector (kindIs "invalid" $cache.nodeSelector) }}
+      {{- $affinity := ternary .Values.gateway.deployment.affinity $cache.affinity (kindIs "invalid" $cache.affinity) }}
+      {{- $topologySpreadConstraints := ternary .Values.gateway.deployment.topologySpreadConstraints $cache.topologySpreadConstraints (kindIs "invalid" $cache.topologySpreadConstraints) }}
+      {{- if $tolerations }}
       tolerations:
-        {{- toYaml .Values.gateway.deployment.tolerations | nindent 8 }}
+        {{- toYaml $tolerations | nindent 8 }}
       {{- end }}
-      {{- if .Values.gateway.deployment.nodeSelector }}
+      {{- if $nodeSelector }}
       nodeSelector:
-        {{- toYaml .Values.gateway.deployment.nodeSelector | nindent 8 }}
+        {{- toYaml $nodeSelector | nindent 8 }}
       {{- end }}
-      {{- if .Values.gateway.deployment.affinity.enabled }}
+      {{- if and $affinity $affinity.enabled }}
       affinity:
-        {{- toYaml .Values.gateway.deployment.affinity.data | nindent 8 }}
+        {{- toYaml $affinity.data | nindent 8 }}
       {{- end }}
-      {{- if .Values.gateway.deployment.topologySpreadConstraints }}
+      {{- if $topologySpreadConstraints }}
       topologySpreadConstraints:
-        {{- toYaml .Values.gateway.deployment.topologySpreadConstraints | nindent 8 }}
+        {{- toYaml $topologySpreadConstraints | nindent 8 }}
       {{- end }}
       {{- if .Values.strictSecurityPolicy.enabled }}
       securityContext:

--- a/charts/akeyless-gateway/templates/akeyless-cache/cache.yaml
+++ b/charts/akeyless-gateway/templates/akeyless-cache/cache.yaml
@@ -43,10 +43,10 @@ spec:
       {{- if .Values.gateway.deployment.affinity.enabled }}
       affinity:
         {{- toYaml .Values.gateway.deployment.affinity.data | nindent 8 }}
+      {{- end }}
       {{- if .Values.gateway.deployment.topologySpreadConstraints }}
       topologySpreadConstraints:
         {{- toYaml .Values.gateway.deployment.topologySpreadConstraints | nindent 8 }}
-      {{- end }}
       {{- end }}
       {{- if .Values.strictSecurityPolicy.enabled }}
       securityContext:

--- a/charts/akeyless-gateway/templates/deployment.yaml
+++ b/charts/akeyless-gateway/templates/deployment.yaml
@@ -42,10 +42,10 @@ spec:
       {{- if .Values.gateway.deployment.affinity.enabled }}
       affinity:
       {{- toYaml .Values.gateway.deployment.affinity.data | nindent 8 }}
+      {{- end }}
       {{- if .Values.gateway.deployment.topologySpreadConstraints }}
       topologySpreadConstraints:
       {{- toYaml .Values.gateway.deployment.topologySpreadConstraints | nindent 8 }}
-      {{- end }}
       {{- end }}
       {{- if or .Values.gateway.deployment.securityContext.enabled .Values.strictSecurityPolicy.enabled }}
       securityContext:

--- a/charts/akeyless-gateway/tests/cluster-cache-scheduling_test.yaml
+++ b/charts/akeyless-gateway/tests/cluster-cache-scheduling_test.yaml
@@ -1,0 +1,123 @@
+suite: akeyless-gateway clusterCache scheduling
+templates:
+  - templates/akeyless-cache/cache.yaml
+tests:
+  - it: inherits gateway tolerations when the cache sets none
+    set:
+      gateway.deployment.tolerations:
+        - key: gateway-only
+          operator: Equal
+          value: "yes"
+          effect: NoSchedule
+    asserts:
+      - equal:
+          path: spec.template.spec.tolerations[0].key
+          value: gateway-only
+
+  - it: prefers its own tolerations over the gateway's
+    set:
+      gateway.deployment.tolerations:
+        - key: gateway-only
+          operator: Equal
+          value: "yes"
+          effect: NoSchedule
+      globalConfig.clusterCache.tolerations:
+        - key: cache-only
+          operator: Equal
+          value: "yes"
+          effect: NoSchedule
+    asserts:
+      - equal:
+          path: spec.template.spec.tolerations[0].key
+          value: cache-only
+      - lengthEqual:
+          path: spec.template.spec.tolerations
+          count: 1
+
+  - it: inherits gateway nodeSelector when the cache sets none
+    set:
+      gateway.deployment.nodeSelector:
+        role: gateway
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector.role
+          value: gateway
+
+  - it: prefers its own nodeSelector over the gateway's
+    set:
+      gateway.deployment.nodeSelector:
+        role: gateway
+      globalConfig.clusterCache.nodeSelector:
+        role: cache
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector.role
+          value: cache
+
+  - it: inherits gateway topologySpreadConstraints when the cache sets none
+    set:
+      gateway.deployment.topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+    asserts:
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].topologyKey
+          value: topology.kubernetes.io/zone
+
+  - it: prefers its own topologySpreadConstraints over the gateway's
+    set:
+      gateway.deployment.topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+      globalConfig.clusterCache.topologySpreadConstraints:
+        - maxSkew: 2
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+    asserts:
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].topologyKey
+          value: kubernetes.io/hostname
+      - lengthEqual:
+          path: spec.template.spec.topologySpreadConstraints
+          count: 1
+
+  - it: prefers its own affinity over the gateway's
+    set:
+      gateway.deployment.affinity:
+        enabled: true
+        data:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: role
+                      operator: In
+                      values: [gateway]
+      globalConfig.clusterCache.affinity:
+        enabled: true
+        data:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: role
+                      operator: In
+                      values: [cache]
+    asserts:
+      - equal:
+          path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]
+          value: cache
+
+  - it: gives the cache no tolerations when explicitly emptied while the gateway has some
+    set:
+      gateway.deployment.tolerations:
+        - key: gateway-only
+          operator: Equal
+          value: "yes"
+          effect: NoSchedule
+      globalConfig.clusterCache.tolerations: []
+    asserts:
+      - notExists:
+          path: spec.template.spec.tolerations

--- a/charts/akeyless-gateway/tests/topology-spread-constraints_test.yaml
+++ b/charts/akeyless-gateway/tests/topology-spread-constraints_test.yaml
@@ -1,0 +1,57 @@
+suite: akeyless-gateway topologySpreadConstraints
+set:
+  gateway.deployment.topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/name: akeyless-gateway
+tests:
+  - it: gateway renders topologySpreadConstraints with affinity at its default
+    template: templates/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].topologyKey
+          value: topology.kubernetes.io/zone
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].whenUnsatisfiable
+          value: ScheduleAnyway
+      - notExists:
+          path: spec.template.spec.affinity
+
+  - it: cache renders topologySpreadConstraints with affinity at its default
+    template: templates/akeyless-cache/cache.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].topologyKey
+          value: topology.kubernetes.io/zone
+      - notExists:
+          path: spec.template.spec.affinity
+
+  - it: gateway renders affinity and topologySpreadConstraints together
+    template: templates/deployment.yaml
+    set:
+      gateway.deployment.affinity.enabled: true
+      gateway.deployment.affinity.data:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: In
+                    values: [linux]
+    asserts:
+      - exists:
+          path: spec.template.spec.affinity.nodeAffinity
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].maxSkew
+          value: 1
+
+  - it: gateway omits topologySpreadConstraints when unset
+    template: templates/deployment.yaml
+    set:
+      gateway.deployment.topologySpreadConstraints: []
+    asserts:
+      - notExists:
+          path: spec.template.spec.topologySpreadConstraints

--- a/charts/akeyless-gateway/values.yaml
+++ b/charts/akeyless-gateway/values.yaml
@@ -148,6 +148,22 @@ globalConfig:
       # storageClass: ""
       # size: 10Gi
 
+    ## Scheduling for the standalone cluster cache pod.
+    ## Each key falls back to the matching gateway.deployment value while left
+    ## unset, which is how the cache behaved before these keys existed. Set a key
+    ## to an empty value to give the cache no constraint of its own.
+    ##
+    tolerations:
+    # - key: "key"
+    #   operator: "Equal"
+    #   value: "value"
+    nodeSelector:
+    affinity:
+    #   enabled: true
+    #   data:
+    #     nodeAffinity: {}
+    topologySpreadConstraints:
+
     ## Pod-level security context for the cache pod.
     ## fsGroup: 1000 is the GID of the redis group in the official Redis Alpine image and is
     ## required when persistence.enabled=true so that the mounted /data volume is chown'ed


### PR DESCRIPTION
Stacked on #436. Review that one first; this branch targets it, not `main`.

## Problem

`templates/akeyless-cache/cache.yaml` read `gateway.deployment.*` for its entire scheduling surface — `tolerations`, `nodeSelector`, `affinity` and `topologySpreadConstraints`. The cluster cache could not be placed anywhere the gateway was not, and nothing in `values.yaml` suggested the two were tied together.

It matters most for taints and node selection rather than spreading: a gateway that tolerates a dedicated-node taint forced the cache onto the same nodes, with no way to express otherwise.

## Change

Adds `globalConfig.clusterCache.{tolerations,nodeSelector,affinity,topologySpreadConstraints}`. Each falls back to the matching `gateway.deployment` value while unset, so existing installs are unaffected.

The fallback tests `kindIs "invalid"` rather than using `default`:

```
{{- $tolerations := ternary .Values.gateway.deployment.tolerations $cache.tolerations (kindIs "invalid" $cache.tolerations) }}
```

With `default`, an explicitly empty list would collapse back to the gateway's value and there would be no way to say "the cache gets no tolerations." This way, unset inherits and empty means none.

## Tests

`tests/cluster-cache-scheduling_test.yaml`, eight cases:

- inherits the gateway value, for each of the four keys
- prefers its own value over the gateway's, for each of the four keys
- explicitly emptied gives the cache none while the gateway keeps its own

Rendering with only `gateway.deployment.*` set is byte-identical to #436's branch, so nothing moves for current users.

Full chart suite: 40 tests across 7 suites, passing.

## Version

3.4.2 to 3.5.0. New values keys rather than a fix, so minor rather than patch.

## Note

`replicas` on the cache deployment is still hardcoded to 1, so `topologySpreadConstraints` on the cache has no practical effect yet. It is included for consistency with the other three keys rather than because it does anything today. Making the cache multi-replica is a separate question.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added independent scheduling controls for cluster-cache pods, including tolerations, node selectors, affinity, and topology spread constraints.
  * Cluster-cache settings inherit Gateway deployment values when not explicitly configured.
  * Explicit empty tolerations can disable inherited Gateway tolerations.

* **Tests**
  * Added coverage for scheduling inheritance, overrides, and disabling inherited settings.

* **Chores**
  * Updated the Helm chart version to 3.5.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->