### PR TITLE
feat(akeyless-gateway): opt-in loadBalancerIP and externalTrafficPolicy on the SRA SSH service

### DIFF
--- a/charts/akeyless-gateway/Chart.yaml
+++ b/charts/akeyless-gateway/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: akeyless-gateway
-version: 3.4.3
+version: 3.5.0
 description: A Helm chart for Kubernetes that deploys akeyless-gateway
 maintainers:
   - name: Akeyless

--- a/charts/akeyless-gateway/templates/akeyless-secure-remote-access/service.yaml
+++ b/charts/akeyless-gateway/templates/akeyless-secure-remote-access/service.yaml
@@ -19,6 +19,12 @@ spec:
   loadBalancerIP: {{ . | quote }}
   {{- end }}
   {{- end }}
+  {{- with .Values.sra.sshConfig.service.externalTrafficPolicy }}
+  {{- if not (has $.Values.sra.sshConfig.service.type (list "LoadBalancer" "NodePort")) }}
+  {{- fail (printf "sra.sshConfig.service.externalTrafficPolicy is set to '%s' but sra.sshConfig.service.type is '%s'; externalTrafficPolicy is only valid for LoadBalancer or NodePort" . $.Values.sra.sshConfig.service.type) }}
+  {{- end }}
+  externalTrafficPolicy: {{ . }}
+  {{- end }}
   ports:
     - port: {{ .Values.sra.sshConfig.service.port }}
       targetPort: ssh

--- a/charts/akeyless-gateway/templates/akeyless-secure-remote-access/service.yaml
+++ b/charts/akeyless-gateway/templates/akeyless-secure-remote-access/service.yaml
@@ -14,6 +14,11 @@ metadata:
   {{- toYaml .Values.sra.sshConfig.service.annotations | nindent 4 }}
 spec:
   type: {{ required "A valid .Values.sra.sshConfig.service.type entry required!" .Values.sra.sshConfig.service.type }}
+  {{- if eq .Values.sra.sshConfig.service.type "LoadBalancer" }}
+  {{- with .Values.sra.sshConfig.service.loadBalancerIP }}
+  loadBalancerIP: {{ . | quote }}
+  {{- end }}
+  {{- end }}
   ports:
     - port: {{ .Values.sra.sshConfig.service.port }}
       targetPort: ssh

--- a/charts/akeyless-gateway/tests/sra-ssh-external-traffic-policy_test.yaml
+++ b/charts/akeyless-gateway/tests/sra-ssh-external-traffic-policy_test.yaml
@@ -1,0 +1,60 @@
+suite: akeyless-gateway SRA SSH service externalTrafficPolicy
+templates:
+  - templates/akeyless-secure-remote-access/service.yaml
+set:
+  sra.enabled: true
+  sra.sshConfig.CAPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC7 test
+tests:
+  - it: omits externalTrafficPolicy when unset, so an existing release is not mutated on upgrade
+    asserts:
+      - notExists:
+          path: spec.externalTrafficPolicy
+        documentSelector:
+          path: metadata.name
+          value: ssh-RELEASE-NAME-akeyless-gateway
+
+  - it: sets externalTrafficPolicy on a LoadBalancer service
+    set:
+      sra.sshConfig.service.externalTrafficPolicy: Local
+    asserts:
+      - equal:
+          path: spec.externalTrafficPolicy
+          value: Local
+        documentSelector:
+          path: metadata.name
+          value: ssh-RELEASE-NAME-akeyless-gateway
+
+  - it: sets externalTrafficPolicy on a NodePort service
+    set:
+      sra.sshConfig.service.type: NodePort
+      sra.sshConfig.service.externalTrafficPolicy: Cluster
+    asserts:
+      - equal:
+          path: spec.externalTrafficPolicy
+          value: Cluster
+        documentSelector:
+          path: metadata.name
+          value: ssh-RELEASE-NAME-akeyless-gateway
+
+  - it: refuses externalTrafficPolicy on a ClusterIP service instead of emitting a manifest the API rejects
+    set:
+      sra.sshConfig.service.type: ClusterIP
+      sra.sshConfig.service.externalTrafficPolicy: Local
+    asserts:
+      - failedTemplate:
+          errorMessage: "sra.sshConfig.service.externalTrafficPolicy is set to 'Local' but sra.sshConfig.service.type is 'ClusterIP'; externalTrafficPolicy is only valid for LoadBalancer or NodePort"
+
+  - it: leaves the internal and web services without externalTrafficPolicy
+    set:
+      sra.sshConfig.service.externalTrafficPolicy: Local
+    asserts:
+      - notExists:
+          path: spec.externalTrafficPolicy
+        documentSelector:
+          path: metadata.name
+          value: ssh-RELEASE-NAME-akeyless-gateway-internal
+      - notExists:
+          path: spec.externalTrafficPolicy
+        documentSelector:
+          path: metadata.name
+          value: web-RELEASE-NAME-akeyless-gateway

--- a/charts/akeyless-gateway/tests/sra-ssh-service_test.yaml
+++ b/charts/akeyless-gateway/tests/sra-ssh-service_test.yaml
@@ -1,0 +1,63 @@
+suite: akeyless-gateway SRA SSH service loadBalancerIP
+templates:
+  - templates/akeyless-secure-remote-access/service.yaml
+set:
+  sra.enabled: true
+  sra.sshConfig.CAPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC7 test
+tests:
+  - it: omits loadBalancerIP when unset
+    asserts:
+      - notExists:
+          path: spec.loadBalancerIP
+        documentSelector:
+          path: metadata.name
+          value: ssh-RELEASE-NAME-akeyless-gateway
+
+  - it: pins loadBalancerIP on the LoadBalancer service
+    set:
+      sra.sshConfig.service.loadBalancerIP: 203.0.113.10
+    asserts:
+      - equal:
+          path: spec.type
+          value: LoadBalancer
+        documentSelector:
+          path: metadata.name
+          value: ssh-RELEASE-NAME-akeyless-gateway
+      - equal:
+          path: spec.loadBalancerIP
+          value: 203.0.113.10
+        documentSelector:
+          path: metadata.name
+          value: ssh-RELEASE-NAME-akeyless-gateway
+
+  - it: omits loadBalancerIP when the service is not a LoadBalancer
+    set:
+      sra.sshConfig.service.type: ClusterIP
+      sra.sshConfig.service.loadBalancerIP: 203.0.113.10
+    asserts:
+      - equal:
+          path: spec.type
+          value: ClusterIP
+        documentSelector:
+          path: metadata.name
+          value: ssh-RELEASE-NAME-akeyless-gateway
+      - notExists:
+          path: spec.loadBalancerIP
+        documentSelector:
+          path: metadata.name
+          value: ssh-RELEASE-NAME-akeyless-gateway
+
+  - it: leaves the internal and web services without loadBalancerIP
+    set:
+      sra.sshConfig.service.loadBalancerIP: 203.0.113.10
+    asserts:
+      - notExists:
+          path: spec.loadBalancerIP
+        documentSelector:
+          path: metadata.name
+          value: ssh-RELEASE-NAME-akeyless-gateway-internal
+      - notExists:
+          path: spec.loadBalancerIP
+        documentSelector:
+          path: metadata.name
+          value: web-RELEASE-NAME-akeyless-gateway

--- a/charts/akeyless-gateway/values.schema.json
+++ b/charts/akeyless-gateway/values.schema.json
@@ -40,6 +40,10 @@
               "service": {
                 "type": "object",
                 "properties": {
+                  "loadBalancerIP": {
+                    "type": "string",
+                    "description": "akeyless-gateway sra.sshConfig.service: a pre-allocated LoadBalancer address. Only rendered when type is LoadBalancer. Empty is the shipped default and renders nothing, so an existing release is never mutated on upgrade."
+                  },
                   "externalTrafficPolicy": {
                     "enum": ["", "Cluster", "Local"],
                     "description": "akeyless-gateway sra.sshConfig.service: Kubernetes accepts only Cluster or Local, and only on an externally-accessible Service. Empty is the shipped default, renders nothing, and never mutates an existing release on upgrade."

--- a/charts/akeyless-gateway/values.schema.json
+++ b/charts/akeyless-gateway/values.schema.json
@@ -31,6 +31,25 @@
           }
         }
       },
+      "sra": {
+        "type": "object",
+        "properties": {
+          "sshConfig": {
+            "type": "object",
+            "properties": {
+              "service": {
+                "type": "object",
+                "properties": {
+                  "externalTrafficPolicy": {
+                    "enum": ["", "Cluster", "Local"],
+                    "description": "akeyless-gateway sra.sshConfig.service: Kubernetes accepts only Cluster or Local, and only on an externally-accessible Service. Empty is the shipped default, renders nothing, and never mutates an existing release on upgrade."
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
       "gatewayAPI": {
         "type": "object",
         "properties": {

--- a/charts/akeyless-gateway/values.yaml
+++ b/charts/akeyless-gateway/values.yaml
@@ -647,6 +647,7 @@ sra:
       annotations: {}
       labels: {}
       type: LoadBalancer
+      loadBalancerIP: ""
       ## External port clients connect to (advertised to users via EXTERNAL_SSH_PORT). The Service
       ## forwards this to the container's named "ssh" port (sshConfig.proxyPort).
       port: 22

--- a/charts/akeyless-gateway/values.yaml
+++ b/charts/akeyless-gateway/values.yaml
@@ -648,6 +648,7 @@ sra:
       labels: {}
       type: LoadBalancer
       loadBalancerIP: ""
+      externalTrafficPolicy: ""
       ## External port clients connect to (advertised to users via EXTERNAL_SSH_PORT). The Service
       ## forwards this to the container's named "ssh" port (sshConfig.proxyPort).
       port: 22


### PR DESCRIPTION
**What this is:** two opt-in Service fields on the SRA SSH Service. `loadBalancerIP` so the bastion IP survives a release delete and recreate, and `externalTrafficPolicy` for source-IP preservation.

TL;DR

- New values `sra.sshConfig.service.loadBalancerIP` and `sra.sshConfig.service.externalTrafficPolicy`, both defaulting to `""`.
- `loadBalancerIP` renders only when `type` is `LoadBalancer`. `externalTrafficPolicy` renders only when set, and **refuses to render** on a service type Kubernetes would reject it on.
- With both unset the SSH Service's `spec` is byte-identical to `main`, so there is nothing for a cloud controller to act on and no existing release's address moves on upgrade.
- `externalTrafficPolicy` is constrained to `Cluster`/`Local` by `values.schema.json`, so a typo fails at parse time rather than at apply time.
- Chart `version` 3.4.3 to 3.5.0. `appVersion` and the image annotations are untouched.

Two fields in one PR because they edit the same `spec:` block of the same Service and share the version bump; shipping them separately would guarantee a rebase conflict on identical lines. The `externalTrafficPolicy` half follows the review left on #377 rather than that PR's implementation.

## Change

| File | Change |
|---|---|
| `templates/akeyless-secure-remote-access/service.yaml` | emit `loadBalancerIP` guarded on `type == LoadBalancer`; emit `externalTrafficPolicy` when set, with a `fail` guard for an incompatible service type |
| `values.yaml` | `loadBalancerIP: ""` and `externalTrafficPolicy: ""` under `sra.sshConfig.service` |
| `values.schema.json` | new `sra` section constraining `externalTrafficPolicy` to `["", "Cluster", "Local"]` |
| `Chart.yaml` | `version: 3.5.0` |
| `tests/sra-ssh-service_test.yaml` | new suite, 4 cases |
| `tests/sra-ssh-external-traffic-policy_test.yaml` | new suite, 5 cases |

Eighteen added lines in the chart templates and values.

## externalTrafficPolicy: why it is opt-in with no default

Kubernetes validates this field against the service type, unlike `loadBalancerIP`
(`pkg/apis/core/validation/validation.go:6557-6575`):

```go
if !apiservice.ExternallyAccessible(service) {
    if service.Spec.ExternalTrafficPolicy != "" {
        ... "may only be set for externally-accessible services"
    }
}
```

Two consequences drove the shape:

- **No default.** A non-null default would add the field to every existing SRA release's Service on `helm upgrade`, which patches the object and can trigger cloud-controller reconciliation on AWS NLB/ELB, GCP and Azure, interrupting live SSH sessions. Empty renders nothing, so the Service `spec` an existing release already has is unchanged until the value is set deliberately.

  Stated precisely, because "byte-identical" is too strong for any version bump: rendering 3.4.3 against 3.5.0 with both values unset differs on the `helm.sh/chart` label of ten objects, the SSH Service among them, plus a chart-version env var in three Deployments. That is what a chart release always does. What matters is that the SSH Service's **`spec`** is byte-identical — the only differing line in the whole object is that label — and `spec` is the only part a cloud controller reads.
- **A `fail` guard, nested inside the set-check.** Setting the field on a `ClusterIP` service produces a manifest the API server rejects while `helm lint` and `helm template` both pass. The guard is deliberately nested so it fires only when the value is set: an unconditional guard would fail every `ClusterIP` user who never asked for the field.

The value enum lives in `values.schema.json` rather than a second template `fail`, because a
static value constraint is checkable at parse time and that is the stronger tier. `""` is
included in the enum on purpose; omitting it would reject every existing release.

## Why the spec field and not an annotation

`.spec.loadBalancerIP` is deprecated as of Kubernetes 1.24, and for most providers an annotation is the replacement. OpenStack is the exception: `cloud-provider-openstack` reads `service.Spec.LoadBalancerIP` directly to select the floating IP for the Octavia VIP port (`pkg/openstack/loadbalancer.go:318`, `:679`, `:731`), and the annotation alternative is an open feature request, not a shipped option (`kubernetes/cloud-provider-openstack#3086`). The chart already passes `annotations` through, so if an annotation could carry this there would be no chart change to make.

## Tests (required)

| Layer | Result |
|---|---|
| `helm lint` | 0 failed |
| `helm unittest` | 41/41, 8 suites |
| `ct lint`, all 6 `ci/` values files | pass, 3.5.0 accepted by `check-version-increment` |
| `ct install` | 2 releases `deployed` on kind |

Every new assertion was run against a deliberately broken template before being trusted.
Reverting the `loadBalancerIP` emit turns its `equal` case red; removing its type guard turns
its `notExists` case red. Removing the `externalTrafficPolicy` service-type guard turns its
`failedTemplate` case red, and the render then produces `type: ClusterIP` alongside
`externalTrafficPolicy: Local` - the manifest the API server rejects. No assertion passes with
its change reverted.

Schema behaviour was checked in both directions: `externalTrafficPolicy=cluster` (lowercase)
is rejected, and unset, `Cluster` and `Local` are all accepted.

## Live verification — OpenStack

Installed on a Kubernetes cluster running `cloud-provider-openstack` v1.34.0
against OpenStack 2026.1 (Keystone, Neutron ML2/OVN, Octavia on the `ovn`
provider). Values used:

```yaml
sra:
  sshConfig:
    service:
      type: LoadBalancer
      loadBalancerIP: "198.51.100.24"
      externalTrafficPolicy: Local
```

The rendered `ssh-<release>-akeyless-gateway` Service carried both fields and
the controller assigned **exactly the requested address**, writing back its own
`loadbalancer.openstack.org/load-balancer-id`.

Delete and recreate, which is the case this is for:

| Step | Service external IP | The pre-allocated floating IP |
|---|---|---|
| install | `198.51.100.24` | attached |
| `helm uninstall` | removed | **still allocated**, `port_id: null` |
| reinstall, same values | `198.51.100.24` | attached again |

A second release with the value unset acts as the control, and the two take
**different code paths in the controller**, visible in Neutron:

| Release | `loadBalancerIP` | Assigned | Floating IP id | Description |
|---|---|---|---|---|
| control | unset | `198.51.100.36` | **new** | `Floating IP for Kubernetes external service …` |
| pinned | `198.51.100.42` | `198.51.100.42` | **pre-existing** | empty |

The pinned release's floating IP keeps the id it had before the install and
still carries no description, so it was looked up and associated rather than
created. That distinction is what makes the address survive a release delete.

### Upgrading an existing release

The claim that an existing release is untouched was verified live, not only by
rendering. The released **3.4.3** chart was installed, given a load balancer and
a floating IP by the controller, then upgraded to this build with both new values
unset.

| Observable | Result |
|---|---|
| SSH Service `spec` byte-identical | **yes** |
| Address served | `198.51.100.23` before and after |
| Octavia load balancer | same id |
| Load balancer `updated_at` | `09:42:12` before **and** after — the controller had nothing to do |
| `helm.sh/chart` label, `resourceVersion` | moved, as every chart release moves them |

A second arm isolates these two fields from the version bump: upgrading 3.5.0 to
3.5.0 with both unset renders identically, so Helm issues no patch and
`resourceVersion` is **unchanged** (`57688` both sides). That is the arm which
shows the new fields contribute nothing when unset; the first arm shows an
existing release survives the upgrade. Neither alone establishes both.

`metadata.generation` is not used as an observable here: it is `<none>` for every
Service on Kubernetes 1.34.0, so comparing it would pass vacuously.

## Live verification — MetalLB

Installed on kind with MetalLB, which also reads `Spec.LoadBalancerIP` (`metallb/controller/service.go:309`). A second release with the value unset acts as the control, so the result is not MetalLB coincidentally handing out the requested address.

| Namespace | `spec.loadBalancerIP` | Assigned |
|---|---|---|
| control | unset | `10.89.0.200` |
| pinned | `10.89.0.207` | `10.89.0.207` |

Pool is `10.89.0.200-10.89.0.210`. The pinned release skipped `.201` and took `.207`.

Delete and recreate, which is the case this is for:

| Step | Assigned |
|---|---|
| install | `10.89.0.207` |
| `helm uninstall` | service removed |
| reinstall, same values | `10.89.0.207` |

## Coverage limits

Stated rather than left implied.

- kind ships no LoadBalancer provider, and every `ci/` values file sets `type: ClusterIP` for that reason, so `ct install` cannot exercise this path. MetalLB on a scratch cluster is where the live proof came from.
- The `ci/` values files also leave `sra.enabled` at its `false` default, so this template does not render during `ct install` at all. Enabling SRA there is not a fix: the SSH bastion does not reach ready with placeholder credentials, so `helm --wait` would time out.
- The OpenStack verification is **control-plane only**. The Octavia deployment used has no compute nodes and no OVN chassis, so no traffic traversed the address — the result establishes allocation, association and lifecycle, not reachability. The bastion pod also never reached ready (placeholder credentials), which does not affect the Service or the floating IP.
- It was run on the **`ovn`** Octavia provider. Delete-time VIP-port handling differs between providers (`octavia_owned` is set by the amphora driver and not by ovn), so the cycle above is not established for amphora.
- MetalLB is not Octavia. That result proves a controller reading `Spec.LoadBalancerIP` receives what this chart emits, independently of provider.

## Out of scope

Deliberately not included, each a separate change if wanted:

- `loadBalancerSourceRanges` on the same Service.
- Either field on `gateway.service`. Raised as point 7 of the review on #377; it is a different Service and belongs in its own change.
- Either field on the standalone `akeyless-sra` chart, which has the identical gap.
- An inline comment in `values.yaml` documenting the valid values. The constraint is enforced by `values.schema.json` and described here instead.
- `README` has no values table, so there is nothing to update there.

## Notes for OpenStack users

`loadBalancerIP` takes two different code paths in `cloud-provider-openstack`,
and the distinction is not visible from the chart
(`pkg/openstack/loadbalancer.go:317-321`):

| Service shape | What `loadBalancerIP` becomes |
|---|---|
| internal (`service.beta.kubernetes.io/openstack-internal-load-balancer`) or IPv6-preferred | the Octavia load balancer's **VipAddress** |
| external and IPv4, the SRA bastion case | a **floating IP**, resolved by `ensureFloatingIP` |

For the external IPv4 case, pre-allocate the floating IP, leave it
**unattached**, and set `loadBalancerIP` to it. `ensureFloatingIP` looks up an
existing floating IP first (`loadbalancer.go:729-745`) and only falls back to
creating one; an already-attached address fails with
`floating IP <addr> is not available`.

### Two things worth knowing before you use this

**It is honoured at create, and ignored on update.** Setting `loadBalancerIP`
on an **existing** release is a silent no-op: `helm upgrade` succeeds, the
Service spec shows the new value, and the address does not move. Verified —
a release given `198.51.100.60` by the controller, then upgraded with
`loadBalancerIP: 198.51.100.24`, still served `198.51.100.60` while its spec
read `198.51.100.24`. Upstream: `cloud-provider-openstack#2443`. Set the value
at install time, or recreate the release.

**What preserves the address is the floating IP's description, not the
`keep-floatingip` annotation.** A pre-allocated floating IP has an empty
description, so the controller does not recognise it as its own and will not
delete it — verified by uninstalling **without** the annotation and finding the
address still allocated. `loadbalancer.openstack.org/keep-floatingip: "true"`
is what protects a floating IP the controller **created** (one whose
description it wrote). It is harmless to set on a pre-allocated address and it
is not what is doing the work.

The corollary is worth stating: because the match is on the description, a
floating IP whose description happens to contain
`Floating IP for Kubernetes external service` is treated as controller-owned
and deleted with the release. Neutron places no restriction on that field, so
avoid quoting that phrase in a description — including in a note explaining
that the address must not be deleted.

### Neutron policy

Creating a floating IP **at a chosen address** is governed by
`create_floatingip:floating_ip_address`, whose current default is
`ADMIN_OR_PROJECT_MANAGER` (`neutron/conf/policies/floatingip.py:62-77`).
Measured on 2026.1 with stock policy, one user, one request, only the role
varied:

| Role | `POST /v2.0/floatingips` with `floating_ip_address` |
|---|---|
| `member` | **403** `PolicyNotAuthorized` |
| `manager` | **201** |

The pre-allocate path avoids the question: **a `member` can associate an
existing unattached floating IP** (`PUT /v2.0/floatingips/<id>` with
`port_id`) — measured **200** for the same user who is refused the create.

Setting `enforce_new_defaults = false` does **not** widen or narrow this.
`oslo.policy` ORs the deprecated rule with the current default rather than
replacing it (`OrCheck([default.check, deprecated_rule.check])`), so a
`member` is refused either way. Note the in-source comment at
`loadbalancer.go:681` still says this is admin-only; that is stale against
Neutron's own policy file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `loadBalancerIP` configuration for SRA SSH LoadBalancer services.
  * Added `externalTrafficPolicy` configuration with support for `Cluster` and `Local` on supported SSH service types.
  * These settings are omitted from internal and web services.
  * Updated the Helm chart to version 3.5.0.

* **Bug Fixes**
  * Added validation to reject unsupported service types and invalid traffic policy values.
  * Added configuration guidance for Kubernetes traffic-handling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


