### PR TITLE
ASM-20178: bump Redis image from 8.6.3 to 8.6.6

### DIFF
--- a/charts/akeyless-api-gateway/Chart.yaml
+++ b/charts/akeyless-api-gateway/Chart.yaml
@@ -16,7 +16,7 @@ maintainers:
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.62.22
+version: 1.62.23
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 5.3.1

--- a/charts/akeyless-api-gateway/values.yaml
+++ b/charts/akeyless-api-gateway/values.yaml
@@ -26,7 +26,7 @@ cache:
     existingSecretName: ""
   image:
     repository: public.ecr.aws/docker/library/redis
-    tag: 8.6.3-alpine
+    tag: 8.6.6-alpine
     pullPolicy: Always
   resources:
     limits:

--- a/charts/akeyless-gateway/Chart.yaml
+++ b/charts/akeyless-gateway/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: akeyless-gateway
-version: 3.5.3
+version: 3.5.4
 description: A Helm chart for Kubernetes that deploys akeyless-gateway
 maintainers:
   - name: Akeyless

--- a/charts/akeyless-gateway/templates/_helpers.tpl
+++ b/charts/akeyless-gateway/templates/_helpers.tpl
@@ -129,7 +129,7 @@ Generate chart secret name
   {{- printf "image: %s:%s\n" (required "A valid .Values.globalConfig.clusterCache.image.repository entry required!" .Values.globalConfig.clusterCache.image.repository) (required "A valid .Values.globalConfig.clusterCache.image.tag entry required!" .Values.globalConfig.clusterCache.image.tag | toString)  -}}
   {{- printf "imagePullPolicy: %s" (.Values.globalConfig.clusterCache.image.imagePullPolicy | default "IfNotPresent"  | quote ) -}}
   {{- else -}}
-  {{- printf "image: %s\n" ("public.ecr.aws/docker/library/redis:8.6.3-alpine" | quote) -}}
+  {{- printf "image: %s\n" ("public.ecr.aws/docker/library/redis:8.6.6-alpine" | quote) -}}
   {{- printf "imagePullPolicy: %s\n" ("IfNotPresent" | quote) -}}
   {{- end -}}
 {{- end -}}

--- a/charts/akeyless-gateway/values.yaml
+++ b/charts/akeyless-gateway/values.yaml
@@ -183,7 +183,7 @@ cacheHA:
 
   image:
     repository: public.ecr.aws/docker/library/redis
-    tag: 8.6.3-alpine
+    tag: 8.6.6-alpine
 
   auth: true
   authKey: redis-password

--- a/charts/akeyless-secure-remote-access/Chart.yaml
+++ b/charts/akeyless-secure-remote-access/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 
-version: 3.5.0
+version: 3.5.1
 appVersion: 3.3.0_2.1.5
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/akeyless-secure-remote-access/templates/_helpers.tpl
+++ b/charts/akeyless-secure-remote-access/templates/_helpers.tpl
@@ -182,7 +182,7 @@ Get the Ingress TLS secret.
     image: "{{ .Values.redisStorage.image.repository }}:{{ .Values.redisStorage.image.tag }}"
     imagePullPolicy: {{ .Values.redisStorage.image.pullPolicy }}
   {{- else }}
-    image: "public.ecr.aws/docker/library/redis:8.6.3-alpine"
+    image: "public.ecr.aws/docker/library/redis:8.6.6-alpine"
     imagePullPolicy: "IfNotPresent"
   {{- end -}}
 {{- end -}}


### PR DESCRIPTION
## Summary
- Bump the Redis Alpine image from `8.6.3` to `8.6.6` in `akeyless-api-gateway`, `akeyless-gateway` (standalone cache fallback and HA cache), and `akeyless-secure-remote-access`.
- Patch-bump chart versions: `akeyless-api-gateway` `1.62.22` → `1.62.23`, `akeyless-gateway` `3.5.3` → `3.5.4`, `akeyless-sra` `3.5.0` → `3.5.1`.
- Leave `appVersion` unchanged; this is a Redis sidecar image update only.

## Test plan
- [ ] `helm lint charts/akeyless-api-gateway`
- [ ] `helm lint charts/akeyless-gateway`
- [ ] `helm lint charts/akeyless-secure-remote-access`
- [ ] Confirm rendered cache/redisStorage images use `public.ecr.aws/docker/library/redis:8.6.6-alpine`
- [ ] CI chart-testing lint/install passes


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Redis components to version 8.6.6-alpine across gateway, API gateway, and secure remote access deployments.
  * Incremented chart versions for the API gateway, gateway, and secure remote access packages to reflect the latest deployment updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->